### PR TITLE
Add GMTRouter to CLI and create test files

### DIFF
--- a/llmrouter/cli/router_inference.py
+++ b/llmrouter/cli/router_inference.py
@@ -28,6 +28,7 @@ from llmrouter.models import (
     SmallestLLM,
     LargestLLM,
     AutomixRouter,
+    GMTRouter,
 )
 from llmrouter.models.llmmultiroundrouter import LLMMultiRoundRouter
 from llmrouter.models.knnmultiroundrouter import KNNMultiRoundRouter
@@ -73,6 +74,10 @@ if GraphRouter is not None:
 if CausalLMRouter is not None:
     ROUTER_REGISTRY["causallm_router"] = CausalLMRouter
     ROUTER_REGISTRY["causallmrouter"] = CausalLMRouter
+
+if GMTRouter is not None:
+    ROUTER_REGISTRY["gmtrouter"] = GMTRouter
+    ROUTER_REGISTRY["gmt_router"] = GMTRouter
 
 # Add RouterR1 if available
 if RouterR1 is not None:

--- a/llmrouter/cli/router_train.py
+++ b/llmrouter/cli/router_train.py
@@ -23,6 +23,7 @@ from llmrouter.models import (
     HybridLLMRouter,
     GraphRouter,
     CausalLMRouter,
+    GMTRouter,
     # Trainers
     KNNRouterTrainer,
     SVMRouterTrainer,
@@ -31,9 +32,10 @@ from llmrouter.models import (
     EloRouterTrainer,
     DCTrainer,
     AutomixRouterTrainer,
-    HybridLLMTrainer, 
+    HybridLLMTrainer,
     GraphTrainer,
     CausalLMTrainer,
+    GMTRouterTrainer,
 )
 
 # Import multi-round routers
@@ -52,12 +54,14 @@ ROUTER_TRAINER_REGISTRY: Dict[str, Tuple[Any, Any]] = {
     "routerdc": (DCRouter, DCTrainer),
     "automix": (AutomixRouter, AutomixRouterTrainer),
     "automixrouter": (AutomixRouter, AutomixRouterTrainer),
-    "hybrid_llm": (HybridLLMRouter, HybridLLMTrainer),      
+    "hybrid_llm": (HybridLLMRouter, HybridLLMTrainer),
     "hybridllm": (HybridLLMRouter, HybridLLMTrainer),
     "graphrouter": (GraphRouter, GraphTrainer),
     "causallm_router": (CausalLMRouter, CausalLMTrainer),
     "causallmrouter": (CausalLMRouter, CausalLMTrainer),
     "knnmultiroundrouter": (KNNMultiRoundRouter, KNNMultiRoundRouterTrainer),
+    "gmtrouter": (GMTRouter, GMTRouterTrainer),
+    "gmt_router": (GMTRouter, GMTRouterTrainer),
 }   
 
 # Routers that do not support training

--- a/tests/inference_test/test_gmtrouter.py
+++ b/tests/inference_test/test_gmtrouter.py
@@ -1,0 +1,113 @@
+import argparse
+import os
+from llmrouter.models import GMTRouter
+
+
+def main():
+    # Correct default path based on your folder structure
+    project_root = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+    default_yaml = os.path.join(project_root, "configs", "model_config_test", "gmtrouter.yaml")
+
+    parser = argparse.ArgumentParser(
+        description="Test the GMTRouter with a YAML configuration file."
+    )
+    parser.add_argument(
+        "--yaml_path",
+        type=str,
+        default=default_yaml,
+        help=f"Path to the YAML config file (default: {default_yaml})",
+    )
+    args = parser.parse_args()
+
+    # Verify file existence
+    if not os.path.exists(args.yaml_path):
+        raise FileNotFoundError(f"YAML file not found: {args.yaml_path}")
+
+    # Initialize the router
+    print(f"📄 Using YAML file: {args.yaml_path}")
+
+    try:
+        router = GMTRouter(args.yaml_path)
+        print("✅ GMTRouter initialized successfully!")
+    except Exception as e:
+        print(f"⚠️  Warning: Could not initialize GMTRouter: {e}")
+        print("This is expected if:")
+        print("  - GMTRouter model checkpoint not found")
+        print("  - PyTorch Geometric not installed")
+        print("  - Training data not available")
+        return
+
+    # Test single query with user context
+    print("\n" + "="*70)
+    print("Testing single query routing...")
+    print("="*70)
+
+    query = {
+        "query_text": "Explain quantum computing in simple terms",
+        "user_id": "test_user_001",
+        "session_id": "test_session_001",
+        "turn": 1,
+        "conversation_history": []
+    }
+
+    try:
+        result = router.route_single(query)
+        print(f"✅ Single query result:")
+        print(f"   Model: {result.get('model_name', 'N/A')}")
+        print(f"   Confidence: {result.get('confidence', 'N/A')}")
+        if 'user_preference' in result:
+            print(f"   User Preference: {result['user_preference']}")
+    except Exception as e:
+        print(f"❌ Single query failed: {e}")
+
+    # Test multi-turn conversation
+    print("\n" + "="*70)
+    print("Testing multi-turn conversation...")
+    print("="*70)
+
+    conversation_queries = [
+        "What is machine learning?",
+        "How does it differ from deep learning?",
+        "Can you give me a practical example?"
+    ]
+
+    try:
+        for turn, query_text in enumerate(conversation_queries, start=1):
+            query = {
+                "query_text": query_text,
+                "user_id": "test_user_002",
+                "session_id": "test_session_002",
+                "turn": turn
+            }
+            result = router.route_single(query)
+            print(f"Turn {turn}: {query_text}")
+            print(f"  → {result.get('model_name', 'N/A')} (confidence: {result.get('confidence', 'N/A')})")
+    except Exception as e:
+        print(f"❌ Multi-turn conversation failed: {e}")
+
+    # Test batch routing
+    print("\n" + "="*70)
+    print("Testing batch routing...")
+    print("="*70)
+
+    try:
+        batch = [
+            {"query_text": "Solve 2+2", "user_id": "user_001", "session_id": "session_1", "turn": 1},
+            {"query_text": "Write a poem", "user_id": "user_001", "session_id": "session_1", "turn": 2},
+            {"query_text": "Debug this code", "user_id": "user_002", "session_id": "session_2", "turn": 1}
+        ]
+
+        results = router.route_batch(batch)
+        print(f"✅ Batch routing results:")
+        for q, r in zip(batch, results):
+            print(f"   '{q['query_text'][:30]}...' → {r.get('model_name', 'N/A')}")
+    except Exception as e:
+        print(f"❌ Batch routing failed: {e}")
+
+    print("\n" + "="*70)
+    print("GMTRouter testing completed!")
+    print("="*70)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/train_test/test_gmtrouter.py
+++ b/tests/train_test/test_gmtrouter.py
@@ -1,0 +1,76 @@
+import argparse
+import os
+from llmrouter.models import GMTRouter
+from llmrouter.models import GMTRouterTrainer
+
+
+def main():
+    # Correct default path based on your folder structure
+    project_root = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+    default_yaml = os.path.join(project_root, "configs", "model_config_train", "gmtrouter.yaml")
+
+    parser = argparse.ArgumentParser(
+        description="Test GMTRouter training with a YAML configuration file."
+    )
+    parser.add_argument(
+        "--yaml_path",
+        type=str,
+        default=default_yaml,
+        help=f"Path to the YAML config file (default: {default_yaml})",
+    )
+    parser.add_argument(
+        "--device",
+        type=str,
+        default="cpu",
+        choices=["cpu", "cuda"],
+        help="Device to use for training (default: cpu)",
+    )
+    args = parser.parse_args()
+
+    # Verify file existence
+    if not os.path.exists(args.yaml_path):
+        raise FileNotFoundError(f"YAML file not found: {args.yaml_path}")
+
+    print("="*70)
+    print("GMTRouter Training Test")
+    print("="*70)
+    print(f"📄 Using YAML file: {args.yaml_path}")
+    print(f"🖥️  Device: {args.device}")
+    print("="*70)
+
+    # Initialize the router
+    try:
+        router = GMTRouter(args.yaml_path)
+        print("✅ GMTRouter initialized successfully!")
+    except Exception as e:
+        print(f"❌ Failed to initialize GMTRouter: {e}")
+        print("\nPossible reasons:")
+        print("  - GMTRouter training data not found")
+        print("  - Data format incorrect (needs GMTRouter JSONL format)")
+        print("  - PyTorch Geometric not installed")
+        print("\nSee llmrouter/models/gmtrouter/README.md for data setup instructions.")
+        return
+
+    # Run training
+    print("\n" + "="*70)
+    print("Starting GMTRouter training...")
+    print("="*70)
+
+    try:
+        trainer = GMTRouterTrainer(router=router, device=args.device)
+        trainer.train()
+        print("\n" + "="*70)
+        print("✅ GMTRouter training completed successfully!")
+        print("="*70)
+    except Exception as e:
+        print(f"\n❌ Training failed: {e}")
+        print("\nPossible issues:")
+        print("  - Training data format incorrect")
+        print("  - Missing required fields in JSONL data")
+        print("  - Insufficient data (need multiple users with >10 interactions each)")
+        print("  - GPU out of memory (try --device cpu)")
+        print("\nCheck the error message above for details.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This commit completes the GMTRouter integration by adding it to the CLI tools and creating comprehensive test files for both training and inference.

Changes:

1. llmrouter/cli/router_train.py - Add GMTRouter to training CLI
   - Import GMTRouter and GMTRouterTrainer
   - Add to ROUTER_TRAINER_REGISTRY with two aliases: "gmtrouter" and "gmt_router"
   - Enables: llmrouter train --router gmtrouter

2. llmrouter/cli/router_inference.py - Add GMTRouter to inference CLI
   - Import GMTRouter
   - Add to ROUTER_REGISTRY as optional router (like GraphRouter)
   - Supports both "gmtrouter" and "gmt_router" aliases
   - Enables: llmrouter infer --router gmtrouter

3. tests/inference_test/test_gmtrouter.py - Inference test suite
   - Single query routing with user context (user_id, session_id, turn)
   - Multi-turn conversation testing (3-turn dialogue)
   - Batch routing with multiple users
   - Comprehensive error handling and user feedback
   - Example queries demonstrating personalization features

4. tests/train_test/test_gmtrouter.py - Training test suite
   - GMTRouter training workflow test
   - Device selection (CPU/CUDA)
   - Detailed error messages for common issues:
     - Missing/incorrect data format
     - PyTorch Geometric not installed - Insufficient training data
   - User-friendly guidance for troubleshooting

Test Features:

Inference Test (test_gmtrouter.py):
- Tests single query with user context: { "query_text": "Explain quantum computing", "user_id": "test_user_001", "session_id": "test_session_001", "turn": 1, "conversation_history": [] }

- Tests multi-turn conversation: Turn 1: "What is machine learning?" Turn 2: "How does it differ from deep learning?" Turn 3: "Can you give me a practical example?"

- Tests batch routing with different users
- Graceful error handling if model not trained

Training Test (test_gmtrouter.py):
- Loads GMTRouter with training config
- Initializes GMTRouterTrainer with device selection
- Runs full training pipeline
- Validates data format automatically
- Provides clear error messages for common issues

CLI Integration:

Users can now:
1. Train GMTRouter: llmrouter train --router gmtrouter --config configs/model_config_train/gmtrouter.yaml

2. Run inference: llmrouter infer --router gmtrouter --query "Your question" --yaml configs/model_config_test/gmtrouter.yaml

3. Test inference: python tests/inference_test/test_gmtrouter.py

4. Test training: python tests/train_test/test_gmtrouter.py --device cpu

This completes the full GMTRouter integration into LLMRouter!