### PR TITLE
Fix GMTRouter config and README inconsistencies

### DIFF
--- a/configs/model_config_train/gmtrouter.yaml
+++ b/configs/model_config_train/gmtrouter.yaml
@@ -18,10 +18,7 @@ train:
   id: llmrouter_gmt                 # Experiment identifier
   epochs: 350                       # Number of training epochs
   lr: 5e-4                          # Learning rate (5e-4 recommended)
-  record_per_user: 10               # Minimum interactions per user
   prediction_count: 256             # Number of predictions per batch
-  multi_turn: false                 # Enable multi-turn conversation mode
-  aggregation_type: mean            # Aggregation: mean, max, attention
   objective: auc                    # Objective: auc or accuracy
   binary: true                      # Binary classification (pairwise comparison)
   eval_every: 5                     # Evaluate every N epochs
@@ -42,17 +39,11 @@ gmt_config:
 
   # Personalization
   personalization: true             # Enable user preference learning
-  record_per_user: 10               # Minimum records per user to learn preferences
 
-  # Node types (fixed in GMTRouter architecture)
-  # - User: User preference embeddings (learned)
-  # - Session: Conversation session representations (learned)
-  # - Query: Query text embeddings (from PLM)
-  # - LLM: Model embeddings (from PLM)
-  # - Response: Response quality (rating-based)
-
-  # Edge types: 21 types in HeteroEdges enum
-  # Including: own, owned_by, answered_by, answered_to, next, prev, etc.
+  # Note: GMTRouter architecture is fixed with:
+  # - 5 Node types: User, Session, Query, LLM, Response
+  # - 21 Edge types: Including own, owned_by, answered_by, answered_to, next, prev, etc.
+  # See llmrouter/models/gmtrouter/data_loader.py for details
 
 # Data paths (for LLMRouter integration)
 data_path:


### PR DESCRIPTION
This commit fixes parameter inconsistencies between configuration files, README documentation, and actual code implementation.

Issues Fixed:

1. Duplicate Parameters (configs/model_config_train/gmtrouter.yaml)
   - Removed duplicate `record_per_user` from train section
   - Removed duplicate `record_per_user` from gmt_config section

2. Unused Parameters (configs/model_config_train/gmtrouter.yaml)
   - Removed `multi_turn` from train section (not implemented in code)
   - Removed `aggregation_type` from train section (not implemented in code)
   - These parameters were in config but never read by trainer.py or router.py

3. README Training Configuration Example (llmrouter/models/gmtrouter/README.md)
   - Updated YAML example to match actual config file
   - Removed: record_per_user, multi_turn, aggregation_type
   - Added: seed parameter (actually used by trainer.py)
   - Fixed comments to match implementation

4. README Configuration Parameters Section (llmrouter/models/gmtrouter/README.md)
   - Removed documentation for unused parameters: - record_per_user (mentioned but not implemented) - multi_turn (mentioned but not implemented) - aggregation_type (mentioned but not implemented)
   - Updated descriptions for existing parameters with more detail
   - Added `seed` parameter documentation (was missing)
   - All documented parameters now match actual code usage

5. README Troubleshooting (llmrouter/models/gmtrouter/README.md)
   - Updated "User not found" troubleshooting to remove reference to record_per_user
   - Made explanation more generic and accurate

Verified Parameter Usage:

Actually Used Parameters (from trainer.py lines 47-76): ✓ gmt_config.hidden_dim (default: 128)
✓ gmt_config.num_gnn_layers (default: 2)
✓ gmt_config.dropout (default: 0.1)
✓ gmt_config.personalization (default: true) - used in router.py ✓ train.epochs (default: 350)
✓ train.lr (default: 5e-4)
✓ train.prediction_count (default: 256)
✓ train.objective (default: "auc")
✓ train.binary (default: true)
✓ train.eval_every (default: 5)
✓ train.seed (default: 136)
✓ checkpoint.root (default: "models")
✓ checkpoint.save_every (default: 25)
✓ model_path.save_model_path

NOT Used (removed from docs):
✗ record_per_user - defined but never read
✗ multi_turn - defined but never read
✗ aggregation_type - defined but never read

Result:
- Configuration file now contains ONLY parameters that are actually used
- README documentation now accurately reflects actual implementation
- No misleading parameter documentation that suggests unimplemented features
- Users won't try to configure parameters that have no effect

This ensures documentation and code are fully consistent.