### PR TITLE
Remove unused legacy classes from data.py

### DIFF
--- a/llmrouter/data/__init__.py
+++ b/llmrouter/data/__init__.py
@@ -1,6 +1,4 @@
 from .data import (
-    Profile,
-    Data,
     # Data format types and validators
     DataFormatType,
     RouterDataFormat,
@@ -21,8 +19,6 @@ from .data import (
 from .data_loader import DataLoader
 
 __all__ = [
-    "Profile",
-    "Data",
     "DataLoader",
     # Data format types
     "DataFormatType",

--- a/llmrouter/data/data.py
+++ b/llmrouter/data/data.py
@@ -56,7 +56,6 @@ Usage Examples:
 from typing import Any, Dict, List, Optional, Union
 from abc import ABC, abstractmethod
 from enum import Enum
-import uuid
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
@@ -66,28 +65,6 @@ class DataFormatType(Enum):
     STANDARD = "standard"  # Standard LLMRouter format
     GMTROUTER = "gmtrouter"  # GMTRouter special JSONL format
     UNKNOWN = "unknown"
-
-
-class Data(BaseModel):
-    """Base data model."""
-    pk: str = Field(default_factory=lambda: str(uuid.uuid4()))
-    project_name: Optional[str] = Field(default=None)
-
-
-class Profile(Data):
-    """User profile data (legacy)."""
-    name: str
-    bio: str
-    collaborators: Optional[List[str]] = Field(default=[])
-    pub_titles: Optional[List[str]] = Field(default=[])
-    pub_abstracts: Optional[List[str]] = Field(default=[])
-    domain: Optional[List[str]] = Field(default=[])
-    institute: Optional[str] = Field(default=None)
-    embed: Optional[Any] = Field(default=None)
-    is_leader_candidate: Optional[bool] = Field(default=True)
-    is_member_candidate: Optional[bool] = Field(default=True)
-    is_reviewer_candidate: Optional[bool] = Field(default=True)
-    is_chair_candidate: Optional[bool] = Field(default=True)
 
 
 # ============================================================================


### PR DESCRIPTION
Remove Profile and Data classes that were legacy code from a different project (researcher matching system). These classes contained fields like is_reviewer_candidate, is_chair_candidate which are unrelated to LLM routing functionality.

Also removed unused uuid import.