### PR TITLE
Reorganize notebook tutorials by router categories

### DIFF
--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -10,11 +10,10 @@ The goal is to help you reproduce the notebook workflows and translate them into
 ## Quick links
 - Workflows: [First routing run](first-routing.md), [Batch inference](batch-inference.md), [Chat demo](chat-demo.md), [Evaluation workflow](evaluation.md), [Custom router](custom-router.md)
 - [Data preparation](notebooks/data-preparation.md)
-- Baselines: [SmallestLLM](notebooks/smallest-llm.md), [LargestLLM](notebooks/largest-llm.md), [EloRouter](notebooks/elorouter.md)
-- Trainable routers: [KNNRouter](notebooks/knnrouter.md), [SVMRouter](notebooks/svmrouter.md), [MLPRouter](notebooks/mlprouter.md), [MFRouter](notebooks/mfrouter.md), [DCRouter](notebooks/dcrouter.md)
-- Advanced trainable routers: [AutoMixRouter](notebooks/automix-router.md), [HybridLLMRouter](notebooks/hybrid-llm-router.md), [GraphRouter](notebooks/graphrouter.md), [CausalLMRouter](notebooks/causallm-router.md), [GMTRouter](notebooks/gmtrouter.md)
-- Multi-round routers: [KNNMultiRoundRouter](notebooks/knnmultiroundrouter.md), [LLMMultiRoundRouter](notebooks/llmmultiroundrouter.md)
-- Inference-only special: [RouterR1](notebooks/router-r1.md)
+- Single-Round Routers: [KNNRouter](notebooks/knnrouter.md), [SVMRouter](notebooks/svmrouter.md), [MLPRouter](notebooks/mlprouter.md), [MFRouter](notebooks/mfrouter.md), [EloRouter](notebooks/elorouter.md), [DCRouter](notebooks/dcrouter.md), [AutoMixRouter](notebooks/automix-router.md), [HybridLLMRouter](notebooks/hybrid-llm-router.md), [GraphRouter](notebooks/graphrouter.md), [CausalLMRouter](notebooks/causallm-router.md), [SmallestLLM](notebooks/smallest-llm.md), [LargestLLM](notebooks/largest-llm.md)
+- Multi-Round Routers: [RouterR1](notebooks/router-r1.md)
+- Personalized Routers: [GMTRouter](notebooks/gmtrouter.md)
+- Agentic Routers: [KNNMultiRoundRouter](notebooks/knnmultiroundrouter.md), [LLMMultiRoundRouter](notebooks/llmmultiroundrouter.md)
 - Extending the framework: [Custom routers](notebooks/custom-router.md)
 
 ## Recommended path

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -185,25 +185,26 @@ nav:
           - Custom router (plugin): tutorials/custom-router.md
       - Notebooks:
           - Data preparation: tutorials/notebooks/data-preparation.md
-          - Baselines:
-              - SmallestLLM: tutorials/notebooks/smallest-llm.md
-              - LargestLLM: tutorials/notebooks/largest-llm.md
-              - EloRouter: tutorials/notebooks/elorouter.md
-          - Trainable routers:
+          - Single-Round Routers:
               - KNNRouter: tutorials/notebooks/knnrouter.md
               - SVMRouter: tutorials/notebooks/svmrouter.md
               - MLPRouter: tutorials/notebooks/mlprouter.md
               - MFRouter: tutorials/notebooks/mfrouter.md
+              - EloRouter: tutorials/notebooks/elorouter.md
               - DCRouter: tutorials/notebooks/dcrouter.md
               - AutoMixRouter: tutorials/notebooks/automix-router.md
               - HybridLLMRouter: tutorials/notebooks/hybrid-llm-router.md
               - GraphRouter: tutorials/notebooks/graphrouter.md
               - CausalLMRouter: tutorials/notebooks/causallm-router.md
+              - SmallestLLM: tutorials/notebooks/smallest-llm.md
+              - LargestLLM: tutorials/notebooks/largest-llm.md
+          - Multi-Round Routers:
+              - RouterR1: tutorials/notebooks/router-r1.md
+          - Personalized Routers:
               - GMTRouter: tutorials/notebooks/gmtrouter.md
-          - Multi-round routers:
+          - Agentic Routers:
               - KNNMultiRoundRouter: tutorials/notebooks/knnmultiroundrouter.md
               - LLMMultiRoundRouter: tutorials/notebooks/llmmultiroundrouter.md
-          - RouterR1: tutorials/notebooks/router-r1.md
           - Custom routers: tutorials/notebooks/custom-router.md
   - API Reference:
       - Overview: api/index.md


### PR DESCRIPTION
- Single-Round Routers: KNN, SVM, MLP, MF, Elo, DC, AutoMix, HybridLLM, Graph, CausalLM, SmallestLLM, LargestLLM
- Multi-Round Routers: RouterR1
- Personalized Routers: GMTRouter
- Agentic Routers: KNNMultiRound, LLMMultiRound

Matches the router categorization in main branch README