### PR TITLE
Add CLI usage documentation to all router READMEs

### DIFF
--- a/llmrouter/models/automix/README.md
+++ b/llmrouter/models/automix/README.md
@@ -104,6 +104,51 @@ During inference:
 - Calls large model if needed
 - No hyperparameters are tuned
 
+## CLI Usage
+
+The Automix Router can be used via the `llmrouter` command-line interface:
+
+### Training
+
+```bash
+# Train the Automix router (learns optimal routing policy)
+llmrouter train --router automix --config configs/model_config_train/automix.yaml
+
+# Train with quiet mode
+llmrouter train --router automix --config configs/model_config_train/automix.yaml --quiet
+```
+
+### Inference
+
+```bash
+# Route a single query (uses self-verification + POMDP policy)
+llmrouter infer --router automix --config configs/model_config_test/automix.yaml \
+    --query "Solve x^2 + 5x + 6 = 0"
+
+# Route queries from a file
+llmrouter infer --router automix --config configs/model_config_test/automix.yaml \
+    --input queries.jsonl --output results.json
+
+# Route only (without calling LLM API)
+llmrouter infer --router automix --config configs/model_config_test/automix.yaml \
+    --query "Explain quantum entanglement" --route-only
+```
+
+### Interactive Chat
+
+```bash
+# Launch chat interface
+llmrouter chat --router automix --config configs/model_config_test/automix.yaml
+
+# Launch with custom port
+llmrouter chat --router automix --config configs/model_config_test/automix.yaml --port 8080
+
+# Create a public shareable link
+llmrouter chat --router automix --config configs/model_config_test/automix.yaml --share
+```
+
+---
+
 ## Usage Examples
 
 ### Training the Automix Router

--- a/llmrouter/models/causallm_router/README.md
+++ b/llmrouter/models/causallm_router/README.md
@@ -61,6 +61,51 @@ Query → Prompt Template → Finetuned LLM (vLLM) → Generated LLM Name → Pa
 | `max_new_tokens` | `32` | Max tokens to generate |
 | `temperature` | `0.1` | Sampling temperature (low for deterministic) |
 
+## CLI Usage
+
+The Causal LM Router can be used via the `llmrouter` command-line interface:
+
+### Training
+
+```bash
+# Train the Causal LM router (requires GPU)
+llmrouter train --router causallmrouter --config configs/model_config_train/causallm_router.yaml --device cuda
+
+# Train with quiet mode
+llmrouter train --router causallmrouter --config configs/model_config_train/causallm_router.yaml --device cuda --quiet
+```
+
+### Inference
+
+```bash
+# Route a single query
+llmrouter infer --router causallmrouter --config configs/model_config_test/causallm_router.yaml \
+    --query "Explain photosynthesis"
+
+# Route queries from a file
+llmrouter infer --router causallmrouter --config configs/model_config_test/causallm_router.yaml \
+    --input queries.jsonl --output results.json
+
+# Route only (without calling LLM API)
+llmrouter infer --router causallmrouter --config configs/model_config_test/causallm_router.yaml \
+    --query "What is machine learning?" --route-only
+```
+
+### Interactive Chat
+
+```bash
+# Launch chat interface
+llmrouter chat --router causallmrouter --config configs/model_config_test/causallm_router.yaml
+
+# Launch with custom port
+llmrouter chat --router causallmrouter --config configs/model_config_test/causallm_router.yaml --port 8080
+
+# Create a public shareable link
+llmrouter chat --router causallmrouter --config configs/model_config_test/causallm_router.yaml --share
+```
+
+---
+
 ## Usage Examples
 
 ### Training

--- a/llmrouter/models/elorouter/README.md
+++ b/llmrouter/models/elorouter/README.md
@@ -124,6 +124,51 @@ During inference:
 - Routes **all queries** to this single model
 - No query-specific routing decisions
 
+## CLI Usage
+
+The ELO Router can be used via the `llmrouter` command-line interface:
+
+### Training
+
+```bash
+# Compute Elo rankings
+llmrouter train --router elorouter --config configs/model_config_train/elorouter.yaml
+
+# Train with quiet mode
+llmrouter train --router elorouter --config configs/model_config_train/elorouter.yaml --quiet
+```
+
+### Inference
+
+```bash
+# Route a single query (always selects highest-rated model)
+llmrouter infer --router elorouter --config configs/model_config_test/elorouter.yaml \
+    --query "What is the meaning of life?"
+
+# Route queries from a file
+llmrouter infer --router elorouter --config configs/model_config_test/elorouter.yaml \
+    --input queries.jsonl --output results.json
+
+# Route only (without calling LLM API)
+llmrouter infer --router elorouter --config configs/model_config_test/elorouter.yaml \
+    --query "Explain quantum mechanics" --route-only
+```
+
+### Interactive Chat
+
+```bash
+# Launch chat interface
+llmrouter chat --router elorouter --config configs/model_config_test/elorouter.yaml
+
+# Launch with custom port
+llmrouter chat --router elorouter --config configs/model_config_test/elorouter.yaml --port 8080
+
+# Create a public shareable link
+llmrouter chat --router elorouter --config configs/model_config_test/elorouter.yaml --share
+```
+
+---
+
 ## Usage Examples
 
 ### Training the ELO Router

--- a/llmrouter/models/gmtrouter/README.md
+++ b/llmrouter/models/gmtrouter/README.md
@@ -167,6 +167,51 @@ After extraction, you should have:
 - **mmlu**: Massive Multitask Language Understanding benchmark
 - **mt_bench**: Multi-turn conversation benchmark
 
+## CLI Usage
+
+GMTRouter can be used via the `llmrouter` command-line interface:
+
+### Training
+
+```bash
+# Train the GMTRouter (GPU recommended)
+llmrouter train --router gmtrouter --config configs/model_config_train/gmtrouter.yaml --device cuda
+
+# Train with quiet mode
+llmrouter train --router gmtrouter --config configs/model_config_train/gmtrouter.yaml --device cuda --quiet
+```
+
+### Inference
+
+```bash
+# Route a single query
+llmrouter infer --router gmtrouter --config configs/model_config_test/gmtrouter.yaml \
+    --query "Explain quantum computing in simple terms"
+
+# Route queries from a file
+llmrouter infer --router gmtrouter --config configs/model_config_test/gmtrouter.yaml \
+    --input queries.jsonl --output results.json
+
+# Route only (without calling LLM API)
+llmrouter infer --router gmtrouter --config configs/model_config_test/gmtrouter.yaml \
+    --query "Solve this calculus problem" --route-only
+```
+
+### Interactive Chat
+
+```bash
+# Launch chat interface
+llmrouter chat --router gmtrouter --config configs/model_config_test/gmtrouter.yaml
+
+# Launch with custom port
+llmrouter chat --router gmtrouter --config configs/model_config_test/gmtrouter.yaml --port 8080
+
+# Create a public shareable link
+llmrouter chat --router gmtrouter --config configs/model_config_test/gmtrouter.yaml --share
+```
+
+---
+
 ## Training GMTRouter
 
 ### ✅ Training Fully Integrated into LLMRouter

--- a/llmrouter/models/graphrouter/README.md
+++ b/llmrouter/models/graphrouter/README.md
@@ -85,6 +85,51 @@ Uses **edge masking** for training:
 | `save_model_path` | Where to save trained GNN model |
 | `load_model_path` | Model to load for inference |
 
+## CLI Usage
+
+The Graph Router can be used via the `llmrouter` command-line interface:
+
+### Training
+
+```bash
+# Train the Graph router (GPU recommended)
+llmrouter train --router graphrouter --config configs/model_config_train/graphrouter.yaml --device cuda
+
+# Train with quiet mode
+llmrouter train --router graphrouter --config configs/model_config_train/graphrouter.yaml --device cuda --quiet
+```
+
+### Inference
+
+```bash
+# Route a single query
+llmrouter infer --router graphrouter --config configs/model_config_test/graphrouter.yaml \
+    --query "Explain quantum mechanics"
+
+# Route queries from a file
+llmrouter infer --router graphrouter --config configs/model_config_test/graphrouter.yaml \
+    --input queries.jsonl --output results.json
+
+# Route only (without calling LLM API)
+llmrouter infer --router graphrouter --config configs/model_config_test/graphrouter.yaml \
+    --query "What is machine learning?" --route-only
+```
+
+### Interactive Chat
+
+```bash
+# Launch chat interface
+llmrouter chat --router graphrouter --config configs/model_config_test/graphrouter.yaml
+
+# Launch with custom port
+llmrouter chat --router graphrouter --config configs/model_config_test/graphrouter.yaml --port 8080
+
+# Create a public shareable link
+llmrouter chat --router graphrouter --config configs/model_config_test/graphrouter.yaml --share
+```
+
+---
+
 ## Usage Examples
 
 ### Training

--- a/llmrouter/models/hybrid_llm/README.md
+++ b/llmrouter/models/hybrid_llm/README.md
@@ -64,6 +64,51 @@ The router supports three decision strategies:
 | `solver` | str | `"adam"` | Optimizer |
 | `max_iter` | int | `300` | Training iterations |
 
+## CLI Usage
+
+The Hybrid LLM Router can be used via the `llmrouter` command-line interface:
+
+### Training
+
+```bash
+# Train the Hybrid LLM router
+llmrouter train --router hybrid_llm --config configs/model_config_train/hybrid_llm.yaml
+
+# Train with quiet mode
+llmrouter train --router hybrid_llm --config configs/model_config_train/hybrid_llm.yaml --quiet
+```
+
+### Inference
+
+```bash
+# Route a single query
+llmrouter infer --router hybrid_llm --config configs/model_config_test/hybrid_llm.yaml \
+    --query "What is photosynthesis?"
+
+# Route queries from a file
+llmrouter infer --router hybrid_llm --config configs/model_config_test/hybrid_llm.yaml \
+    --input queries.jsonl --output results.json
+
+# Route only (without calling LLM API)
+llmrouter infer --router hybrid_llm --config configs/model_config_test/hybrid_llm.yaml \
+    --query "Explain neural networks" --route-only
+```
+
+### Interactive Chat
+
+```bash
+# Launch chat interface
+llmrouter chat --router hybrid_llm --config configs/model_config_test/hybrid_llm.yaml
+
+# Launch with custom port
+llmrouter chat --router hybrid_llm --config configs/model_config_test/hybrid_llm.yaml --port 8080
+
+# Create a public shareable link
+llmrouter chat --router hybrid_llm --config configs/model_config_test/hybrid_llm.yaml --share
+```
+
+---
+
 ## Usage Examples
 
 ### Training

--- a/llmrouter/models/knnmultiroundrouter/README.md
+++ b/llmrouter/models/knnmultiroundrouter/README.md
@@ -56,6 +56,51 @@ Query → Decomposition → [Sub-Query 1, Sub-Query 2, ...]
 | `use_local_llm` | bool | `false` | Use local vLLM (true) or API (false) |
 | `api_endpoint` | str | - | API endpoint for sub-query execution |
 
+## CLI Usage
+
+The KNN Multi-Round Router can be used via the `llmrouter` command-line interface:
+
+### Training
+
+```bash
+# Train the KNN Multi-Round router (builds KNN index)
+llmrouter train --router knnmultiroundrouter --config configs/model_config_train/knnmultiroundrouter.yaml
+
+# Train with quiet mode
+llmrouter train --router knnmultiroundrouter --config configs/model_config_train/knnmultiroundrouter.yaml --quiet
+```
+
+### Inference
+
+```bash
+# Route a single query with decomposition
+llmrouter infer --router knnmultiroundrouter --config configs/model_config_test/knnmultiroundrouter.yaml \
+    --query "Explain climate change and its causes"
+
+# Route queries from a file
+llmrouter infer --router knnmultiroundrouter --config configs/model_config_test/knnmultiroundrouter.yaml \
+    --input queries.jsonl --output results.json
+
+# Route only (without calling LLM API)
+llmrouter infer --router knnmultiroundrouter --config configs/model_config_test/knnmultiroundrouter.yaml \
+    --query "What causes earthquakes?" --route-only
+```
+
+### Interactive Chat
+
+```bash
+# Launch chat interface
+llmrouter chat --router knnmultiroundrouter --config configs/model_config_test/knnmultiroundrouter.yaml
+
+# Launch with custom port
+llmrouter chat --router knnmultiroundrouter --config configs/model_config_test/knnmultiroundrouter.yaml --port 8080
+
+# Create a public shareable link
+llmrouter chat --router knnmultiroundrouter --config configs/model_config_test/knnmultiroundrouter.yaml --share
+```
+
+---
+
 ## Usage Examples
 
 ### Inference (Chat Mode)

--- a/llmrouter/models/knnrouter/README.md
+++ b/llmrouter/models/knnrouter/README.md
@@ -89,6 +89,51 @@ During inference:
 - Performs nearest neighbor search for each new query
 - No retraining needed — can add new examples instantly
 
+## CLI Usage
+
+The KNN Router can be used via the `llmrouter` command-line interface:
+
+### Training
+
+```bash
+# "Train" the KNN router (builds search index)
+llmrouter train --router knnrouter --config configs/model_config_train/knnrouter.yaml
+
+# Train with quiet mode
+llmrouter train --router knnrouter --config configs/model_config_train/knnrouter.yaml --quiet
+```
+
+### Inference
+
+```bash
+# Route a single query
+llmrouter infer --router knnrouter --config configs/model_config_test/knnrouter.yaml \
+    --query "What are the ethical implications of AI?"
+
+# Route queries from a file
+llmrouter infer --router knnrouter --config configs/model_config_test/knnrouter.yaml \
+    --input queries.jsonl --output results.json
+
+# Route only (without calling LLM API)
+llmrouter infer --router knnrouter --config configs/model_config_test/knnrouter.yaml \
+    --query "Explain neural networks" --route-only
+```
+
+### Interactive Chat
+
+```bash
+# Launch chat interface
+llmrouter chat --router knnrouter --config configs/model_config_test/knnrouter.yaml
+
+# Launch with custom port
+llmrouter chat --router knnrouter --config configs/model_config_test/knnrouter.yaml --port 8080
+
+# Create a public shareable link
+llmrouter chat --router knnrouter --config configs/model_config_test/knnrouter.yaml --share
+```
+
+---
+
 ## Usage Examples
 
 ### "Training" the KNN Router

--- a/llmrouter/models/largest_llm/README.md
+++ b/llmrouter/models/largest_llm/README.md
@@ -40,6 +40,43 @@ Requires only `llm_data` with model sizes:
 
 Router will select "Llama-70B" (largest).
 
+## CLI Usage
+
+The Largest LLM Router can be used via the `llmrouter` command-line interface:
+
+### Inference
+
+> **Note**: This router does not require training - it's a zero-shot heuristic.
+
+```bash
+# Route a single query (always selects largest model)
+llmrouter infer --router largest_llm --config configs/model_config_test/largest_llm.yaml \
+    --query "What is machine learning?"
+
+# Route queries from a file
+llmrouter infer --router largest_llm --config configs/model_config_test/largest_llm.yaml \
+    --input queries.jsonl --output results.json
+
+# Route only (without calling LLM API)
+llmrouter infer --router largest_llm --config configs/model_config_test/largest_llm.yaml \
+    --query "Explain neural networks" --route-only
+```
+
+### Interactive Chat
+
+```bash
+# Launch chat interface
+llmrouter chat --router largest_llm --config configs/model_config_test/largest_llm.yaml
+
+# Launch with custom port
+llmrouter chat --router largest_llm --config configs/model_config_test/largest_llm.yaml --port 8080
+
+# Create a public shareable link
+llmrouter chat --router largest_llm --config configs/model_config_test/largest_llm.yaml --share
+```
+
+---
+
 ## Usage
 
 ```python

--- a/llmrouter/models/llmmultiroundrouter/README.md
+++ b/llmrouter/models/llmmultiroundrouter/README.md
@@ -61,6 +61,43 @@ Query → LLM Decomposition+Routing → [(Sub-Query 1, Model A), (Sub-Query 2, M
 
 Requires `llm_data` with model descriptions for routing prompts.
 
+## CLI Usage
+
+The LLM Multi-Round Router can be used via the `llmrouter` command-line interface:
+
+### Inference
+
+> **Note**: This router does not require training - it uses zero-shot LLM prompts.
+
+```bash
+# Route a single query with decomposition
+llmrouter infer --router llmmultiroundrouter --config configs/model_config_test/llmmultiroundrouter.yaml \
+    --query "Compare neural networks and decision trees"
+
+# Route queries from a file
+llmrouter infer --router llmmultiroundrouter --config configs/model_config_test/llmmultiroundrouter.yaml \
+    --input queries.jsonl --output results.json
+
+# Route only (without calling LLM API)
+llmrouter infer --router llmmultiroundrouter --config configs/model_config_test/llmmultiroundrouter.yaml \
+    --query "Explain machine learning concepts" --route-only
+```
+
+### Interactive Chat
+
+```bash
+# Launch chat interface
+llmrouter chat --router llmmultiroundrouter --config configs/model_config_test/llmmultiroundrouter.yaml
+
+# Launch with custom port
+llmrouter chat --router llmmultiroundrouter --config configs/model_config_test/llmmultiroundrouter.yaml --port 8080
+
+# Create a public shareable link
+llmrouter chat --router llmmultiroundrouter --config configs/model_config_test/llmmultiroundrouter.yaml --share
+```
+
+---
+
 ## Usage Examples
 
 ### Inference

--- a/llmrouter/models/mfrouter/README.md
+++ b/llmrouter/models/mfrouter/README.md
@@ -84,6 +84,54 @@ Where:
 | `save_model_path` | Where to save trained model | Training: saves model state_dict as `.pkl` |
 | `load_model_path` | Model to load for inference | Testing: loads trained model weights |
 
+## CLI Usage
+
+The MF Router can be used via the `llmrouter` command-line interface:
+
+### Training
+
+```bash
+# Train the MF router
+llmrouter train --router mfrouter --config configs/model_config_train/mfrouter.yaml
+
+# Train with GPU acceleration
+llmrouter train --router mfrouter --config configs/model_config_train/mfrouter.yaml --device cuda
+
+# Train with quiet mode
+llmrouter train --router mfrouter --config configs/model_config_train/mfrouter.yaml --quiet
+```
+
+### Inference
+
+```bash
+# Route a single query
+llmrouter infer --router mfrouter --config configs/model_config_test/mfrouter.yaml \
+    --query "Explain neural networks"
+
+# Route queries from a file
+llmrouter infer --router mfrouter --config configs/model_config_test/mfrouter.yaml \
+    --input queries.jsonl --output results.json
+
+# Route only (without calling LLM API)
+llmrouter infer --router mfrouter --config configs/model_config_test/mfrouter.yaml \
+    --query "What is deep learning?" --route-only
+```
+
+### Interactive Chat
+
+```bash
+# Launch chat interface
+llmrouter chat --router mfrouter --config configs/model_config_test/mfrouter.yaml
+
+# Launch with custom port
+llmrouter chat --router mfrouter --config configs/model_config_test/mfrouter.yaml --port 8080
+
+# Create a public shareable link
+llmrouter chat --router mfrouter --config configs/model_config_test/mfrouter.yaml --share
+```
+
+---
+
 ## Usage Examples
 
 ### Training the MF Router

--- a/llmrouter/models/mlprouter/README.md
+++ b/llmrouter/models/mlprouter/README.md
@@ -89,6 +89,54 @@ During inference, the router uses:
 
 No hyperparameters are tuned during inference — all decisions are made by the trained model.
 
+## CLI Usage
+
+The MLP Router can be used via the `llmrouter` command-line interface:
+
+### Training
+
+```bash
+# Train the MLP router
+llmrouter train --router mlprouter --config configs/model_config_train/mlprouter.yaml
+
+# Train with GPU acceleration
+llmrouter train --router mlprouter --config configs/model_config_train/mlprouter.yaml --device cuda
+
+# Train with quiet mode (less verbose output)
+llmrouter train --router mlprouter --config configs/model_config_train/mlprouter.yaml --quiet
+```
+
+### Inference
+
+```bash
+# Route a single query
+llmrouter infer --router mlprouter --config configs/model_config_test/mlprouter.yaml \
+    --query "What is machine learning?"
+
+# Route queries from a file
+llmrouter infer --router mlprouter --config configs/model_config_test/mlprouter.yaml \
+    --input queries.jsonl --output results.json
+
+# Route only (without calling LLM API)
+llmrouter infer --router mlprouter --config configs/model_config_test/mlprouter.yaml \
+    --query "Explain neural networks" --route-only
+```
+
+### Interactive Chat
+
+```bash
+# Launch chat interface
+llmrouter chat --router mlprouter --config configs/model_config_test/mlprouter.yaml
+
+# Launch with custom port
+llmrouter chat --router mlprouter --config configs/model_config_test/mlprouter.yaml --port 8080
+
+# Create a public shareable link
+llmrouter chat --router mlprouter --config configs/model_config_test/mlprouter.yaml --share
+```
+
+---
+
 ## Usage Examples
 
 ### Training the MLP Router

--- a/llmrouter/models/router_r1/README.md
+++ b/llmrouter/models/router_r1/README.md
@@ -87,6 +87,43 @@ Supports any vLLM-compatible chat model:
 
 The router automatically detects the model family and applies the appropriate prompt template.
 
+## CLI Usage
+
+Router-R1 can be used via the `llmrouter` command-line interface:
+
+### Inference
+
+> **Note**: This router does not require training - it's a zero-shot agentic system.
+
+```bash
+# Route a single query with agentic reasoning
+llmrouter infer --router router_r1 --config configs/model_config_test/router_r1.yaml \
+    --query "Explain how transformers work in machine learning"
+
+# Route queries from a file
+llmrouter infer --router router_r1 --config configs/model_config_test/router_r1.yaml \
+    --input queries.jsonl --output results.json
+
+# Route only (without calling LLM API)
+llmrouter infer --router router_r1 --config configs/model_config_test/router_r1.yaml \
+    --query "What is quantum computing?" --route-only
+```
+
+### Interactive Chat
+
+```bash
+# Launch chat interface
+llmrouter chat --router router_r1 --config configs/model_config_test/router_r1.yaml
+
+# Launch with custom port
+llmrouter chat --router router_r1 --config configs/model_config_test/router_r1.yaml --port 8080
+
+# Create a public shareable link
+llmrouter chat --router router_r1 --config configs/model_config_test/router_r1.yaml --share
+```
+
+---
+
 ## Usage Examples
 
 ### Inference: Routing a Single Query

--- a/llmrouter/models/routerdc/README.md
+++ b/llmrouter/models/routerdc/README.md
@@ -113,6 +113,51 @@ This dual approach ensures the router learns both:
 | `save_model_path` | Where to save the trained model | Training: saves best model checkpoint |
 | `load_model_path` | Model to load for inference | Testing: loads trained model weights |
 
+## CLI Usage
+
+RouterDC can be used via the `llmrouter` command-line interface:
+
+### Training
+
+```bash
+# Train the RouterDC (GPU recommended)
+llmrouter train --router routerdc --config configs/model_config_train/routerdc.yaml --device cuda
+
+# Train with quiet mode
+llmrouter train --router routerdc --config configs/model_config_train/routerdc.yaml --device cuda --quiet
+```
+
+### Inference
+
+```bash
+# Route a single query
+llmrouter infer --router routerdc --config configs/model_config_test/routerdc.yaml \
+    --query "Explain the concept of machine learning"
+
+# Route queries from a file
+llmrouter infer --router routerdc --config configs/model_config_test/routerdc.yaml \
+    --input queries.jsonl --output results.json
+
+# Route only (without calling LLM API)
+llmrouter infer --router routerdc --config configs/model_config_test/routerdc.yaml \
+    --query "What is deep learning?" --route-only
+```
+
+### Interactive Chat
+
+```bash
+# Launch chat interface
+llmrouter chat --router routerdc --config configs/model_config_test/routerdc.yaml
+
+# Launch with custom port
+llmrouter chat --router routerdc --config configs/model_config_test/routerdc.yaml --port 8080
+
+# Create a public shareable link
+llmrouter chat --router routerdc --config configs/model_config_test/routerdc.yaml --share
+```
+
+---
+
 ## Usage Examples
 
 ### Training the RouterDC

--- a/llmrouter/models/smallest_llm/README.md
+++ b/llmrouter/models/smallest_llm/README.md
@@ -40,6 +40,43 @@ Requires only `llm_data` with model sizes:
 
 Router will select "Qwen2.5-3B" (smallest).
 
+## CLI Usage
+
+The Smallest LLM Router can be used via the `llmrouter` command-line interface:
+
+### Inference
+
+> **Note**: This router does not require training - it's a zero-shot heuristic.
+
+```bash
+# Route a single query (always selects smallest model)
+llmrouter infer --router smallest_llm --config configs/model_config_test/smallest_llm.yaml \
+    --query "What is machine learning?"
+
+# Route queries from a file
+llmrouter infer --router smallest_llm --config configs/model_config_test/smallest_llm.yaml \
+    --input queries.jsonl --output results.json
+
+# Route only (without calling LLM API)
+llmrouter infer --router smallest_llm --config configs/model_config_test/smallest_llm.yaml \
+    --query "Explain neural networks" --route-only
+```
+
+### Interactive Chat
+
+```bash
+# Launch chat interface
+llmrouter chat --router smallest_llm --config configs/model_config_test/smallest_llm.yaml
+
+# Launch with custom port
+llmrouter chat --router smallest_llm --config configs/model_config_test/smallest_llm.yaml --port 8080
+
+# Create a public shareable link
+llmrouter chat --router smallest_llm --config configs/model_config_test/smallest_llm.yaml --share
+```
+
+---
+
 ## Usage
 
 ```python

--- a/llmrouter/models/svmrouter/README.md
+++ b/llmrouter/models/svmrouter/README.md
@@ -97,6 +97,51 @@ During inference, the router:
 - Applies the decision function to predict the optimal LLM
 - No hyperparameters are tuned during inference
 
+## CLI Usage
+
+The SVM Router can be used via the `llmrouter` command-line interface:
+
+### Training
+
+```bash
+# Train the SVM router
+llmrouter train --router svmrouter --config configs/model_config_train/svmrouter.yaml
+
+# Train with quiet mode
+llmrouter train --router svmrouter --config configs/model_config_train/svmrouter.yaml --quiet
+```
+
+### Inference
+
+```bash
+# Route a single query
+llmrouter infer --router svmrouter --config configs/model_config_test/svmrouter.yaml \
+    --query "Explain the theory of relativity"
+
+# Route queries from a file
+llmrouter infer --router svmrouter --config configs/model_config_test/svmrouter.yaml \
+    --input queries.jsonl --output results.json
+
+# Route only (without calling LLM API)
+llmrouter infer --router svmrouter --config configs/model_config_test/svmrouter.yaml \
+    --query "What is machine learning?" --route-only
+```
+
+### Interactive Chat
+
+```bash
+# Launch chat interface
+llmrouter chat --router svmrouter --config configs/model_config_test/svmrouter.yaml
+
+# Launch with custom port
+llmrouter chat --router svmrouter --config configs/model_config_test/svmrouter.yaml --port 8080
+
+# Create a public shareable link
+llmrouter chat --router svmrouter --config configs/model_config_test/svmrouter.yaml --share
+```
+
+---
+
 ## Usage Examples
 
 ### Training the SVM Router


### PR DESCRIPTION
Added "## CLI Usage" section to all 16 router READMEs with:
- Training commands (llmrouter train) where applicable
- Inference commands (llmrouter infer) with examples
- Interactive chat commands (llmrouter chat)

Routers that support training:
- mlprouter, mfrouter, svmrouter, knnrouter, elorouter
- routerdc, automix, hybrid_llm, graphrouter
- causallmrouter, knnmultiroundrouter, gmtrouter

Zero-shot routers (no training needed):
- smallest_llm, largest_llm, llmmultiroundrouter, router_r1