### PR TITLE
Add environment variable support for RouterR1 API config

### DIFF
--- a/configs/model_config_test/router_r1.yaml
+++ b/configs/model_config_test/router_r1.yaml
@@ -1,4 +1,15 @@
-# Config parameters for largest_llm:
+# Config parameters for Router-R1:
+#
+# API Configuration:
+#   You can configure api_base and api_key either:
+#   1. In this YAML file (below)
+#   2. Via environment variables:
+#      - API Key: OPENAI_API_KEY, NVIDIA_API_KEY, NVAPI_KEY, or ROUTER_API_KEY
+#      - API Base: OPENAI_API_BASE, NVIDIA_API_BASE, or ROUTER_API_BASE
+#
+# Example:
+#   export OPENAI_API_KEY='your-api-key'
+#   export OPENAI_API_BASE='https://api.openai.com/v1'
 
 
 data_path:
@@ -18,7 +29,14 @@ metric:
 
 
 hparam:
-  model_id: "ulab-ai/Router-R1-Qwen2.5-3B-Instruct"        # Model ID from HF Repo: "ulab-ai/Router-R1-Qwen2.5-3B-Instruct", "ulab-ai/Router-R1-Qwen2.5-3B-Instruct-Alpha0.9", "ulab-ai/Router-R1-Llama-3.2-3B-Instruct", "ulab-ai/Router-R1-Llama-3.2-3B-Instruct-Alpha0.9"
-  api_base: ""    # API BASE
-  api_key: ""     # API KEY"
+  # Model ID from HF Repo:
+  #   - "ulab-ai/Router-R1-Qwen2.5-3B-Instruct"
+  #   - "ulab-ai/Router-R1-Qwen2.5-3B-Instruct-Alpha0.9"
+  #   - "ulab-ai/Router-R1-Llama-3.2-3B-Instruct"
+  #   - "ulab-ai/Router-R1-Llama-3.2-3B-Instruct-Alpha0.9"
+  model_id: "ulab-ai/Router-R1-Qwen2.5-3B-Instruct"
+
+  # API settings (leave empty to use environment variables)
+  api_base: ""    # or set OPENAI_API_BASE / NVIDIA_API_BASE env var
+  api_key: ""     # or set OPENAI_API_KEY / NVIDIA_API_KEY env var
 

--- a/llmrouter/models/router_r1/README.md
+++ b/llmrouter/models/router_r1/README.md
@@ -64,8 +64,29 @@ Total cost = prompt_tokens + completion_tokens + route_tokens
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `model_id` | str | Yes | HuggingFace model ID for vLLM (e.g., `"Qwen/Qwen2.5-7B-Instruct"`) |
-| `api_base` | str | Yes | Base URL for the routing pool API |
-| `api_key` | str | Yes | API key for accessing the routing pool |
+| `api_base` | str | Yes* | Base URL for the routing pool API |
+| `api_key` | str | Yes* | API key for accessing the routing pool |
+
+*Can be set via environment variables instead of YAML config.
+
+### Environment Variables
+
+Instead of setting `api_base` and `api_key` in the YAML config, you can use environment variables:
+
+| Config Key | Environment Variables (checked in order) |
+|------------|------------------------------------------|
+| `api_key` | `OPENAI_API_KEY`, `NVIDIA_API_KEY`, `NVAPI_KEY`, `ROUTER_API_KEY` |
+| `api_base` | `OPENAI_API_BASE`, `NVIDIA_API_BASE`, `ROUTER_API_BASE` |
+
+**Example:**
+```bash
+export OPENAI_API_KEY='your-api-key'
+export OPENAI_API_BASE='https://api.openai.com/v1'
+
+# Now you can run without setting api_key/api_base in YAML
+llmrouter infer --router router_r1 --config configs/model_config_test/router_r1.yaml \
+    --query "Explain transformers"
+```
 
 ### Dependencies
 


### PR DESCRIPTION
- RouterR1 now reads api_key and api_base from environment variables if not set in YAML config
- Supported env vars for api_key: OPENAI_API_KEY, NVIDIA_API_KEY, NVAPI_KEY, ROUTER_API_KEY
- Supported env vars for api_base: OPENAI_API_BASE, NVIDIA_API_BASE, ROUTER_API_BASE
- Updated config file with usage examples
- Updated README with environment variable documentation