### PR TITLE
Unify RouterR1 env vars with project standard (API_KEYS, API_BASE)

### DIFF
--- a/configs/model_config_test/router_r1.yaml
+++ b/configs/model_config_test/router_r1.yaml
@@ -3,13 +3,13 @@
 # API Configuration:
 #   You can configure api_base and api_key either:
 #   1. In this YAML file (below)
-#   2. Via environment variables:
-#      - API Key: OPENAI_API_KEY, NVIDIA_API_KEY, NVAPI_KEY, or ROUTER_API_KEY
-#      - API Base: OPENAI_API_BASE, NVIDIA_API_BASE, or ROUTER_API_BASE
+#   2. Via environment variables (same as other routers):
+#      - API Key: API_KEYS
+#      - API Base: API_BASE
 #
 # Example:
-#   export OPENAI_API_KEY='your-api-key'
-#   export OPENAI_API_BASE='https://api.openai.com/v1'
+#   export API_KEYS='your-api-key'
+#   export API_BASE='https://api.openai.com/v1'
 
 
 data_path:
@@ -37,6 +37,6 @@ hparam:
   model_id: "ulab-ai/Router-R1-Qwen2.5-3B-Instruct"
 
   # API settings (leave empty to use environment variables)
-  api_base: ""    # or set OPENAI_API_BASE / NVIDIA_API_BASE env var
-  api_key: ""     # or set OPENAI_API_KEY / NVIDIA_API_KEY env var
+  api_base: ""    # or set API_BASE env var
+  api_key: ""     # or set API_KEYS env var
 

--- a/llmrouter/models/router_r1/README.md
+++ b/llmrouter/models/router_r1/README.md
@@ -71,17 +71,29 @@ Total cost = prompt_tokens + completion_tokens + route_tokens
 
 ### Environment Variables
 
-Instead of setting `api_base` and `api_key` in the YAML config, you can use environment variables:
+Instead of setting `api_base` and `api_key` in the YAML config, you can use the same environment variables as other routers:
 
-| Config Key | Environment Variables (checked in order) |
-|------------|------------------------------------------|
-| `api_key` | `OPENAI_API_KEY`, `NVIDIA_API_KEY`, `NVAPI_KEY`, `ROUTER_API_KEY` |
-| `api_base` | `OPENAI_API_BASE`, `NVIDIA_API_BASE`, `ROUTER_API_BASE` |
+| Config Key | Environment Variable |
+|------------|---------------------|
+| `api_key` | `API_KEYS` |
+| `api_base` | `API_BASE` |
+
+**`API_KEYS` Format** (same as other routers):
+```bash
+# JSON Array Format (recommended for multiple keys)
+export API_KEYS='["your-key-1", "your-key-2", "your-key-3"]'
+
+# Comma-Separated Format
+export API_KEYS='key1,key2,key3'
+
+# Single Key
+export API_KEYS='your-api-key'
+```
 
 **Example:**
 ```bash
-export OPENAI_API_KEY='your-api-key'
-export OPENAI_API_BASE='https://api.openai.com/v1'
+export API_KEYS='your-api-key'
+export API_BASE='https://api.openai.com/v1'
 
 # Now you can run without setting api_key/api_base in YAML
 llmrouter infer --router router_r1 --config configs/model_config_test/router_r1.yaml \


### PR DESCRIPTION
- Use API_KEYS for api_key (supports JSON array, comma-separated, single key)
- Use API_BASE for api_base
- Consistent with other routers in the project
- Updated config file and README documentation