### PR TITLE
feat: add WebSocket support for real-time streaming responses (#159)

### DIFF
--- a/openclaw_router/README.md
+++ b/openclaw_router/README.md
@@ -522,6 +522,7 @@ Once running, the following endpoints are available:
 | `/health` | GET | Health check |
 | `/v1/chat/completions` | POST | Chat completions (OpenAI-compatible) |
 | `/v1/models` | GET | List available models |
+| `/v1/chat/ws` | WS | Real-time streaming chat (WebSocket) |
 | `/routers` | GET | List available routing strategies |
 
 Quick checks:
@@ -544,6 +545,9 @@ curl -N http://127.0.0.1:8000/v1/chat/completions \
     "messages": [{"role": "user", "content": "Hello (streaming)"}],
     "stream": true
   }'
+
+# WebSocket Streaming
+# See tests/test_websocket.py for a Python client example
 ```
 
 ## Usage Examples

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
   "protobuf>=3.20",
   "fastapi",
   "uvicorn",
+  "websockets",
   "httpx",
 ]
 

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -1,0 +1,36 @@
+import asyncio
+import json
+try:
+    import websockets
+except ImportError:
+    print("Please install: pip install websockets")
+    exit(1)
+
+async def test_ws():
+    uri = "ws://localhost:8000/v1/chat/ws"
+    async with websockets.connect(uri) as websocket:
+        request = {
+            "model": "auto",
+            "messages": [
+                {"role": "user", "content": "Tell me a short joke."}
+            ],
+            "stream": True
+        }
+        
+        print(f"Sending request to {uri}...")
+        await websocket.send(json.dumps(request))
+        
+        print("Receiving response...")
+        try:
+            while True:
+                response = await websocket.recv()
+                print(f"Received: {response}")
+                if "[DONE]" in response:
+                    break
+        except websockets.exceptions.ConnectionClosedOK:
+            print("Connection closed normally")
+        except Exception as e:
+            print(f"Error: {e}")
+
+if __name__ == "__main__":
+    asyncio.run(test_ws())


### PR DESCRIPTION
## Description

Enable WebSocket connections for real-time streaming of router responses. This addition provides a persistent, low-latency communication channel for interactive applications.

## Related Issues

- Fixes #159

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [x] Test addition or update

## Changes Made

- Implemented WebSocket endpoint `/v1/chat/ws` in `openclaw_router/server.py`.
- Implemented WebSocket endpoint `/v1/chat/ws` in `llmrouter/serve/server.py`.
- Added a standalone test client in `tests/test_websocket.py`.
- Updated `openclaw_router/README.md` with WebSocket usage instructions.

## Router Affected (if applicable)

- [x] Other / Core framework

## Checklist

- [x] I have tested my changes locally
- [x] I have reviewed my own code
- [x] I have added/updated documentation where necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes do not introduce new warnings or errors

## Test Plan

Tested using the provided WebSocket client script against the OpenClaw Router server with NVIDIA-hosted models.

```bash
# Start server
llmrouter serve --config openclaw_router/config.yaml

# Run WebSocket test client
python tests/test_websocket.py
```

## Screenshots (if applicable)

No scrrenshots needed

## Additional Notes

The implementation follows OpenAI's streaming payload structure for maximum compatibility with existing toolchains.