### PR TITLE
Add benchmark_pipeline: one-command train/eval of all routers on xRouteBench

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@
 - [ComfyUI Interface](#-comfyui-interface)
 - [Creating Your Own Routers](#-creating-your-own-routers)
 - [Adding Your Own Tasks](#-adding-your-own-tasks)
+- [xRouteBench Benchmark Pipeline](#-xroutebench-benchmark-pipeline)
 - [OpenClaw Router (OpenClaw Integration)](#-openclaw-router-openclaw-integration)
 - [Acknowledgments](#-acknowledgments)
 - [Citation](#-citation)
@@ -738,6 +739,29 @@ For detailed guides on creating custom tasks:
 ### 🎥 Hands-on: Multi-View Video Tasks
 
 Follow our **step-by-step walkthrough** in the [Charades-Ego Integration Guide](data/charades_ego/README.md) to process paired egocentric videos, generate VLM-based features, and train routers for **Activity**, **Object**, and **Verb** recognition.
+
+## 📈 xRouteBench Benchmark Pipeline
+
+Reproduce the full router benchmark with one command. The
+[`benchmark_pipeline/`](benchmark_pipeline/) folder trains and evaluates
+**17 routers on the 8 [xRouteBench](https://huggingface.co/datasets/ulab-ai/xRouteBench)
+datasets** (classic NLP, memory, time-series, video, multimodal math,
+personalized), including cost-aware Pareto training with a composite
+`alpha * performance - beta * cost` reward.
+
+```bash
+cd benchmark_pipeline
+python download_data.py        # pull data from HF (ulab-ai/xRouteBench)
+python generate_embeddings.py  # Qwen3-Embedding-0.6B query embeddings
+python run_pipeline.py --datasets all --routers local   # 13 local routers, zero API cost
+python aggregate_results.py --csv                       # per-dataset tables + overall ranking
+```
+
+Evaluation **replays pre-recorded model executions** — every query in
+xRouteBench was pre-run against all 18 candidate LLMs — so the local-router
+sweep costs nothing to run. API-calling routers (multi-round, Router-R1,
+Automix) are available behind `--include-api-routers`. See
+[`benchmark_pipeline/README.md`](benchmark_pipeline/README.md) for details.
 
 ## 🔌 OpenClaw Router (OpenClaw Integration)
 

--- a/benchmark_pipeline/.gitignore
+++ b/benchmark_pipeline/.gitignore
@@ -1,0 +1,3 @@
+data/
+results/
+__pycache__/

--- a/benchmark_pipeline/README.md
+++ b/benchmark_pipeline/README.md
@@ -1,0 +1,89 @@
+# Benchmark Pipeline — train & evaluate every router on xRouteBench
+
+One-command pipeline that trains and evaluates LLMRouter's routers on the
+[xRouteBench](https://huggingface.co/datasets/ulab-ai/xRouteBench) benchmark
+(8 datasets), including cost-aware training with a GraphRouter-style composite
+reward.
+
+## Quick start
+
+```bash
+# 1. Get the data (HF_TOKEN needed while the dataset repo is private)
+python download_data.py
+
+# 2. Generate query embeddings (Qwen3-Embedding-0.6B, needs one GPU)
+python generate_embeddings.py
+
+# 3. Run the sweep — all local routers x all 8 datasets, pure-performance
+python run_pipeline.py --datasets all --routers local
+
+# 4. Aggregate into tables
+python aggregate_results.py --csv
+```
+
+Results land in `results/<dataset>_<router>_a<alpha>_b<beta>.json`.
+Completed pairs are skipped on re-run, so the sweep is resumable.
+
+## Datasets (8)
+
+| Dataset | Domain | Test queries |
+|---|---|---|
+| `llmrouter_generic` | 13 classic NLP benchmarks (MMLU, GSM8K, MATH, MBPP, …) | 3,729 |
+| `memory_locomo` | Long-conversation memory QA (RAG top-k=5) | 314 |
+| `memory_longmemeval` | Long-term memory eval (RAG top-k=5) | 101 |
+| `timeseries` | Time-series understanding (7 sub-tasks) | 127 |
+| `video` | Egocentric video QA (Charades-Ego) | 27 |
+| `multimodal_geometry3k` | Geometry math | 61 |
+| `multimodal_mathvista` | Visual math reasoning | 100 |
+| `personalized` | Personalized preference (chat-format queries) | 303 |
+
+Every query was pre-executed against all 18 candidate LLMs, so **evaluation
+replays recorded outcomes — no API calls or cost** for the local router
+category.
+
+## Routers (17)
+
+| Category | Routers | Notes |
+|---|---|---|
+| Embedding-based | `knnrouter` `svmrouter` `mlprouter` `mfrouter` `elorouter` `graphrouter` `routerdc` `hybrid_llm` | trained on query embeddings |
+| Baselines | `largest_llm` `smallest_llm` | no training |
+| Generic trainable | `gmtrouter` `personalizedrouter` | trained via the repo registry |
+| Heavy | `causallm_router` | LoRA-finetunes Llama-2-7b + vLLM inference; runs train/infer as separate processes (a single process OOMs one 48GB GPU); needs `HF_TOKEN` with Llama-2 access |
+| API-calling | `knnmultiroundrouter` `llmmultiroundrouter` `router_r1` `automix` | make live LLM calls at inference; enable with `--include-api-routers`, set `LLM_API_KEY` (+ `ROUTER_R1_API_BASE` for router_r1) |
+
+`--routers local` = the first four categories (13 routers, zero API cost).
+
+## Cost-aware (Pareto) training
+
+```bash
+# reward = alpha * norm(performance) - beta * norm(price_cost)
+for a in 1.0 0.8 0.6 0.4 0.2; do
+  b=$(python -c "print(round(1-$a,1))")
+  python run_pipeline.py --datasets all --routers local --alpha $a --beta $b
+done
+python aggregate_results.py
+```
+
+Training data's `performance` column is replaced by the composite reward
+(per-column min-max normalization), so any router that "picks the best model
+per query" automatically becomes cost-aware. Price cost uses the per-model
+prices in `data/llm_candidates/default_llm.json`:
+`cost = input_tokens x input_price/1e6 + output_tokens x output_price/1e6`.
+
+## Output format
+
+```json
+{
+  "router": "graphrouter", "dataset": "timeseries", "alpha": 0.6, "beta": 0.4,
+  "avg_performance": 0.4724, "avg_token_cost": 183.9,
+  "avg_price_cost": 2.9e-05, "avg_reward": 0.17,
+  "num_queries": 127, "routing_distribution": {"gpt-oss-20b": 127}
+}
+```
+
+## Requirements
+
+- Core: `llmrouter` package (this repo) + `datasets` (HF download)
+- `generate_embeddings.py` / `graphrouter` / `routerdc` / `mlprouter` / `mfrouter`: GPU recommended
+- `causallm_router`: GPU (>=40GB), `vllm`, `peft`, gated `meta-llama/Llama-2-7b-hf` access
+- API routers: provider API key(s); these calls spend real money

--- a/benchmark_pipeline/_causallm_stage.py
+++ b/benchmark_pipeline/_causallm_stage.py
@@ -1,0 +1,84 @@
+"""CausalLMRouter stage runner (invoked by run_pipeline.py as a subprocess).
+
+Training fills a GPU with the LoRA-finetuned base model; loading vLLM in the
+same process OOMs a single 48GB card. Running the two stages as separate
+processes keeps each within one GPU.
+"""
+
+import argparse
+import json
+import os
+import sys
+
+import pandas as pd
+import yaml
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.dirname(HERE)
+sys.path.insert(0, REPO_ROOT)
+
+DATA_DIR = os.path.join(HERE, "data")
+RESULTS_DIR = os.path.join(HERE, "results")
+POOL_DIR = os.path.join(DATA_DIR, "llm_candidates")
+
+
+def stage_train(yaml_path):
+    hf = os.environ.get("HF_TOKEN", "")
+    if hf:
+        os.environ["HUGGING_FACE_HUB_TOKEN"] = hf
+    from llmrouter.models.causallm_router import CausalLMRouter, CausalLMTrainer
+    router = CausalLMRouter(yaml_path)
+    trainer = CausalLMTrainer(router=router, device="cuda")
+    trainer.train()
+    print("[causallm] train done")
+
+
+def stage_infer(dataset, alpha, beta, yaml_path):
+    from vllm import LLM, SamplingParams
+    from llmrouter.models.causallm_router import CausalLMRouter
+
+    with open(yaml_path) as f:
+        cfg = yaml.safe_load(f)
+    router = CausalLMRouter(yaml_path)
+    merged = os.path.join(REPO_ROOT, cfg["model_path"]["load_model_path"])
+    vllm_model = LLM(model=merged, trust_remote_code=True,
+                     tensor_parallel_size=1, gpu_memory_utilization=0.9)
+    sp = SamplingParams(max_tokens=32, temperature=0.1, top_p=0.95,
+                        stop=["\n", "Query:", "Available"])
+
+    test_path = cfg["data_path"]["routing_data_test"]
+    test_df = pd.read_json(test_path, lines=True)
+    uq = test_df.groupby("query", sort=False).first().reset_index()
+    prompts = [router._build_prompt(q) for q in uq["query"]]
+    outs = vllm_model.generate(prompts, sp)
+    routing = [{"query": row["query"],
+                "routed_model": router._parse_llm_name(outs[i].outputs[0].text)}
+               for i, (_, row) in enumerate(uq.iterrows())]
+
+    # replay evaluation (same convention as run_pipeline.evaluate)
+    from run_pipeline import evaluate, load_pricing, result_path
+    metrics = evaluate(routing, test_path, load_pricing(), alpha, beta)
+    if metrics is None:
+        sys.exit("[causallm] no valid replay rows")
+    summary = {"router": "causallm_router", "dataset": dataset,
+               "alpha": alpha, "beta": beta, **metrics}
+    os.makedirs(RESULTS_DIR, exist_ok=True)
+    out = result_path(dataset, "causallm_router", alpha, beta)
+    with open(out, "w") as f:
+        json.dump(summary, f, indent=2)
+    print(f"[causallm] perf={metrics['avg_performance']} reward={metrics['avg_reward']} -> {out}")
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dataset", required=True)
+    ap.add_argument("--alpha", type=float, required=True)
+    ap.add_argument("--beta", type=float, required=True)
+    ap.add_argument("--yaml", required=True)
+    ap.add_argument("--device", default="cuda")
+    ap.add_argument("--stage", required=True, choices=["train", "infer"])
+    args = ap.parse_args()
+    if args.stage == "train":
+        stage_train(args.yaml)
+    else:
+        stage_infer(args.dataset, args.alpha, args.beta, args.yaml)

--- a/benchmark_pipeline/aggregate_results.py
+++ b/benchmark_pipeline/aggregate_results.py
@@ -1,0 +1,102 @@
+"""Aggregate benchmark_pipeline/results/*.json into markdown tables.
+
+Usage:
+    python aggregate_results.py                # writes results/tables.md
+    python aggregate_results.py --csv          # also writes results/results.csv
+"""
+
+import argparse
+import glob
+import json
+import os
+from collections import defaultdict
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+RESULTS_DIR = os.path.join(HERE, "results")
+
+DATASET_ORDER = [
+    "llmrouter_generic", "memory_locomo", "memory_longmemeval", "timeseries",
+    "video", "multimodal_geometry3k", "multimodal_mathvista", "personalized",
+]
+
+
+def load_all():
+    out = []
+    for f in glob.glob(os.path.join(RESULTS_DIR, "*.json")):
+        with open(f) as fh:
+            out.append(json.load(fh))
+    return out
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--csv", action="store_true")
+    args = parser.parse_args()
+
+    results = load_all()
+    if not results:
+        raise SystemExit("no results found; run run_pipeline.py first")
+
+    weights = sorted({(r["alpha"], r["beta"]) for r in results}, key=lambda w: -w[0])
+    datasets = [d for d in DATASET_ORDER
+                if any(r["dataset"] == d for r in results)]
+
+    lines = ["# Benchmark Pipeline Results", ""]
+
+    # Per-dataset tables, one per weight setting
+    for ds in datasets:
+        lines += [f"## {ds}", ""]
+        for (a, b) in weights:
+            rows = [r for r in results if r["dataset"] == ds
+                    and r["alpha"] == a and r["beta"] == b]
+            if not rows:
+                continue
+            rows.sort(key=lambda r: -(r.get("avg_reward") or 0))
+            lines += [f"### alpha={a}, beta={b}", "",
+                      "| Router | Performance | Token Cost | Price Cost ($) | Reward |",
+                      "|--------|------------|-----------|---------------|--------|"]
+            for r in rows:
+                lines.append(f"| {r['router']} | {r['avg_performance']:.4f} | "
+                             f"{r['avg_token_cost']:.1f} | {r['avg_price_cost']:.8f} | "
+                             f"{r['avg_reward']:.4f} |")
+            lines.append("")
+
+    # Overall ranking per weight setting
+    lines += ["## Overall ranking (averaged across datasets)", ""]
+    for (a, b) in weights:
+        agg = defaultdict(lambda: {"perf": [], "cost": [], "reward": []})
+        for r in results:
+            if r["alpha"] == a and r["beta"] == b:
+                agg[r["router"]]["perf"].append(r["avg_performance"])
+                agg[r["router"]]["cost"].append(r["avg_price_cost"])
+                agg[r["router"]]["reward"].append(r["avg_reward"])
+        ranked = sorted(agg.items(), key=lambda kv: -sum(kv[1]["reward"]) / len(kv[1]["reward"]))
+        lines += [f"### alpha={a}, beta={b}", "",
+                  "| Rank | Router | Avg Performance | Avg Price Cost ($) | Avg Reward | #Datasets |",
+                  "|------|--------|----------------|-------------------|-----------|-----------|"]
+        for i, (router, s) in enumerate(ranked, 1):
+            n = len(s["perf"])
+            lines.append(f"| {i} | {router} | {sum(s['perf'])/n:.4f} | "
+                         f"{sum(s['cost'])/n:.8f} | {sum(s['reward'])/n:.4f} | {n} |")
+        lines.append("")
+
+    out_md = os.path.join(RESULTS_DIR, "tables.md")
+    with open(out_md, "w") as f:
+        f.write("\n".join(lines) + "\n")
+    print("wrote", out_md)
+
+    if args.csv:
+        import csv
+        out_csv = os.path.join(RESULTS_DIR, "results.csv")
+        keys = ["dataset", "router", "alpha", "beta", "avg_performance",
+                "avg_token_cost", "avg_price_cost", "avg_reward", "num_queries"]
+        with open(out_csv, "w", newline="") as f:
+            w = csv.DictWriter(f, fieldnames=keys, extrasaction="ignore")
+            w.writeheader()
+            for r in sorted(results, key=lambda r: (r["dataset"], r["router"], -r["alpha"])):
+                w.writerow(r)
+        print("wrote", out_csv)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark_pipeline/configs/hparams.yaml
+++ b/benchmark_pipeline/configs/hparams.yaml
@@ -1,0 +1,107 @@
+# Per-router hyperparameters used by run_pipeline.py.
+# These mirror the settings used for the published xRouteBench baseline numbers.
+
+knnrouter:
+  n_neighbors: 5
+  weights: uniform
+  algorithm: auto
+  leaf_size: 30
+  p: 2
+  metric: minkowski
+  n_jobs: -1
+
+svmrouter:
+  kernel: rbf
+  C: 1.0
+  gamma: scale
+  probability: true
+
+mlprouter:
+  hidden_layer_sizes: [256, 128]
+  activation: relu
+  lr: 0.001
+  epochs: 100
+  batch_size: 32
+  alpha: 0.0001
+
+mfrouter:
+  latent_dim: 128
+  text_dim: 1024
+  lr: 0.001
+  epochs: 20
+  batch_size: 64
+  noise_alpha: 0.0
+
+elorouter: {}
+
+graphrouter:
+  hidden_dim: 256
+  learning_rate: 0.005
+  weight_decay: 0.0001
+  train_epoch: 300
+  batch_size: 8
+  train_mask_rate: 0.5
+  temperature: 0.1
+  val_split_ratio: 0.2
+  random_state: 42
+
+routerdc:
+  hidden_state_dim: 768
+  similarity_function: cosine
+  source_max_token_len: 512
+  target_max_token_len: 512
+  n_clusters: 3
+  learning_rate: 1.0e-05
+  batch_size: 16
+  training_steps: 2000
+  eval_steps: 200
+  gradient_accumulation: 1
+  temperature: 0.07
+  top_k: 1
+  last_k: 1
+  sample_loss_weight: 0.0
+  cluster_loss_weight: 0.0
+  H: 1.0
+  device: cuda
+  inference_temperature: 1.0
+  inference_batch_size: 64
+
+hybrid_llm:
+  hidden_layer_sizes: [128, 64]
+  max_iter: 500
+  random_state: 42
+
+largest_llm: {}
+smallest_llm: {}
+
+gmtrouter: {}
+personalizedrouter: {}
+
+causallm_router:
+  base_model: meta-llama/Llama-2-7b-hf
+  use_lora: true
+  lora_r: 16
+  lora_alpha: 32
+  lora_dropout: 0.1
+  merge_lora: true
+  num_epochs: 3
+  batch_size: 4
+  gradient_accumulation_steps: 4
+  learning_rate: 2.0e-05
+  max_length: 512
+  max_new_tokens: 32
+  temperature: 0.1
+  tensor_parallel_size: 1
+  gpu_memory_utilization: 0.9
+
+# API-calling routers (run with --include-api-routers; needs LLM_API_KEY)
+knnmultiroundrouter:
+  n_neighbors: 5
+  weights: uniform
+
+llmmultiroundrouter: {}
+
+router_r1: {}
+
+automix:
+  method: threshold

--- a/benchmark_pipeline/download_data.py
+++ b/benchmark_pipeline/download_data.py
@@ -1,0 +1,84 @@
+"""Download xRouteBench routing data from Hugging Face into the local layout
+expected by the LLMRouter training/inference pipeline.
+
+Creates, per dataset:
+    benchmark_pipeline/data/<dataset>/routing_data_train.jsonl
+    benchmark_pipeline/data/<dataset>/routing_data_test.jsonl
+plus the shared candidate pool:
+    benchmark_pipeline/data/llm_candidates/default_llm.json
+
+Usage:
+    python download_data.py                    # all datasets
+    python download_data.py --datasets video memory_locomo
+    HF_TOKEN=hf_xxx python download_data.py    # token needed while the repo is private
+"""
+
+import argparse
+import json
+import os
+
+HF_REPO = "ulab-ai/xRouteBench"
+DATASETS = [
+    "llmrouter_generic", "memory_locomo", "memory_longmemeval", "timeseries",
+    "video", "multimodal_geometry3k", "multimodal_mathvista", "personalized",
+]
+# Fields that were JSON-encoded during the parquet conversion; decode them back.
+MAYBE_JSON_FIELDS = ["ground_truth", "choices", "query"]
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+DATA_DIR = os.path.join(HERE, "data")
+
+
+def maybe_json_decode(value):
+    if isinstance(value, str) and value[:1] in ("[", "{"):
+        try:
+            return json.loads(value)
+        except (json.JSONDecodeError, TypeError):
+            return value
+    return value
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--datasets", nargs="*", default=DATASETS, choices=DATASETS)
+    args = parser.parse_args()
+
+    from datasets import load_dataset
+    token = os.environ.get("HF_TOKEN")
+
+    for ds_name in args.datasets:
+        out_dir = os.path.join(DATA_DIR, ds_name)
+        os.makedirs(out_dir, exist_ok=True)
+        ds = load_dataset(HF_REPO, ds_name, token=token)
+        for split in ("train", "test"):
+            out_path = os.path.join(out_dir, f"routing_data_{split}.jsonl")
+            with open(out_path, "w") as f:
+                for row in ds[split]:
+                    for field in MAYBE_JSON_FIELDS:
+                        if field in row:
+                            row[field] = maybe_json_decode(row[field])
+                    f.write(json.dumps(row, ensure_ascii=False) + "\n")
+            print(f"{ds_name}/{split}: {len(ds[split])} rows -> {out_path}")
+
+    # Candidate pool with pricing
+    pool = load_dataset(HF_REPO, "llm_candidates", token=token)["train"]
+    os.makedirs(os.path.join(DATA_DIR, "llm_candidates"), exist_ok=True)
+    llm_json = {}
+    for row in pool:
+        llm_json[row["model_name"]] = {
+            "size": row["size"],
+            "feature": row["description"],
+            "input_price": row["input_price_per_1m"],
+            "output_price": row["output_price_per_1m"],
+            "model": row["api_model_id"],
+            "service": row["service"],
+        }
+    pool_path = os.path.join(DATA_DIR, "llm_candidates", "default_llm.json")
+    with open(pool_path, "w") as f:
+        json.dump(llm_json, f, indent=2, ensure_ascii=False)
+    print(f"llm_candidates: {len(llm_json)} models -> {pool_path}")
+    print("\nNext step: python generate_embeddings.py")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark_pipeline/generate_embeddings.py
+++ b/benchmark_pipeline/generate_embeddings.py
@@ -1,0 +1,122 @@
+"""Generate query embeddings (and LLM-candidate embeddings) for the benchmark data.
+
+Mirrors the original xRouteBench embedding setup: Qwen/Qwen3-Embedding-0.6B,
+last-token pooling, L2-normalized. Produces, per dataset:
+
+    benchmark_pipeline/data/<dataset>/query_embeddings_train.pt
+    benchmark_pipeline/data/<dataset>/query_embeddings_test.pt
+
+Embeddings are indexed by the `embedding_id` column of the routing data, so
+tensor row i corresponds to embedding_id == i.
+
+Also produces the candidate-description embeddings:
+    benchmark_pipeline/data/llm_candidates/default_llm_embeddings.json
+
+Usage:
+    python generate_embeddings.py                       # all datasets + candidates
+    python generate_embeddings.py --datasets video
+    python generate_embeddings.py --device cuda:1 --batch-size 16
+"""
+
+import argparse
+import json
+import os
+
+import pandas as pd
+import torch
+from transformers import AutoModel, AutoTokenizer
+
+DATASETS = [
+    "llmrouter_generic", "memory_locomo", "memory_longmemeval", "timeseries",
+    "video", "multimodal_geometry3k", "multimodal_mathvista", "personalized",
+]
+MODEL_NAME = "Qwen/Qwen3-Embedding-0.6B"
+HERE = os.path.dirname(os.path.abspath(__file__))
+DATA_DIR = os.path.join(HERE, "data")
+
+
+def last_token_pool(last_hidden_states, attention_mask):
+    left_padding = attention_mask[:, -1].sum() == attention_mask.shape[0]
+    if left_padding:
+        return last_hidden_states[:, -1]
+    seq_lens = attention_mask.sum(dim=1) - 1
+    batch = torch.arange(last_hidden_states.shape[0], device=last_hidden_states.device)
+    return last_hidden_states[batch, seq_lens]
+
+
+def embed_texts(texts, tokenizer, model, device, batch_size=8, max_length=512):
+    out = []
+    for i in range(0, len(texts), batch_size):
+        chunk = texts[i:i + batch_size]
+        inputs = tokenizer(chunk, return_tensors="pt", padding=True,
+                           truncation=True, max_length=max_length)
+        inputs = {k: v.to(device) for k, v in inputs.items()}
+        with torch.no_grad():
+            outputs = model(**inputs)
+            emb = last_token_pool(outputs.last_hidden_state, inputs["attention_mask"])
+            emb = torch.nn.functional.normalize(emb, p=2, dim=1)
+        out.append(emb.cpu())
+        if (i // batch_size) % 50 == 0:
+            print(f"  {i + len(chunk)}/{len(texts)}", flush=True)
+    return torch.cat(out, dim=0)
+
+
+def query_to_text(q):
+    """personalized stores queries as chat-message lists; flatten to text."""
+    if isinstance(q, list):
+        return "\n".join(m.get("content", "") for m in q if isinstance(m, dict))
+    return str(q)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--datasets", nargs="*", default=DATASETS, choices=DATASETS)
+    parser.add_argument("--device", default="cuda:0" if torch.cuda.is_available() else "cpu")
+    parser.add_argument("--batch-size", type=int, default=8)
+    parser.add_argument("--skip-candidates", action="store_true")
+    args = parser.parse_args()
+
+    tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME, trust_remote_code=True,
+                                              padding_side="left")
+    model = AutoModel.from_pretrained(MODEL_NAME, trust_remote_code=True)
+    model = model.to(args.device).eval()
+
+    for ds in args.datasets:
+        for split in ("train", "test"):
+            src = os.path.join(DATA_DIR, ds, f"routing_data_{split}.jsonl")
+            dst = os.path.join(DATA_DIR, ds, f"query_embeddings_{split}.pt")
+            if not os.path.exists(src):
+                print(f"skip {ds}/{split}: {src} missing (run download_data.py first)")
+                continue
+            if os.path.exists(dst):
+                print(f"skip {ds}/{split}: embeddings already exist")
+                continue
+            df = pd.read_json(src, lines=True)
+            # one embedding per embedding_id, ordered by id
+            uniq = (df[["embedding_id", "query"]]
+                    .drop_duplicates("embedding_id")
+                    .sort_values("embedding_id"))
+            texts = [query_to_text(q) for q in uniq["query"]]
+            print(f"{ds}/{split}: embedding {len(texts)} unique queries ...")
+            emb = embed_texts(texts, tokenizer, model, args.device, args.batch_size)
+            torch.save(emb, dst)
+            print(f"  -> {dst}  shape={tuple(emb.shape)}")
+
+    if not args.skip_candidates:
+        pool_path = os.path.join(DATA_DIR, "llm_candidates", "default_llm.json")
+        out_path = os.path.join(DATA_DIR, "llm_candidates", "default_llm_embeddings.json")
+        if os.path.exists(pool_path) and not os.path.exists(out_path):
+            pool = json.load(open(pool_path))
+            names = list(pool.keys())
+            texts = [pool[n].get("feature", n) for n in names]
+            print(f"llm_candidates: embedding {len(texts)} model descriptions ...")
+            emb = embed_texts(texts, tokenizer, model, args.device, args.batch_size)
+            json.dump({n: emb[i].tolist() for i, n in enumerate(names)},
+                      open(out_path, "w"))
+            print(f"  -> {out_path}")
+
+    print("\nNext step: python run_pipeline.py --datasets all --routers local")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark_pipeline/run_pipeline.py
+++ b/benchmark_pipeline/run_pipeline.py
@@ -1,0 +1,446 @@
+"""One-command train + evaluate pipeline for all routers on all xRouteBench datasets.
+
+Examples:
+    # Everything local (13 trainable/baseline routers x 8 datasets, no API calls)
+    python run_pipeline.py --datasets all --routers local
+
+    # A specific pair
+    python run_pipeline.py --datasets memory_locomo --routers knnrouter,graphrouter
+
+    # Cost-aware (GraphRouter-style composite reward) training
+    python run_pipeline.py --datasets all --routers local --alpha 0.6 --beta 0.4
+
+    # Include API-calling routers (needs API keys, spends money)
+    python run_pipeline.py --datasets video --routers all --include-api-routers
+
+Results land in benchmark_pipeline/results/<dataset>_<router>_a<alpha>_b<beta>.json
+(existing results are skipped, so the sweep is resumable). Aggregate with:
+    python aggregate_results.py
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+import numpy as np
+import pandas as pd
+import yaml
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.dirname(HERE)
+sys.path.insert(0, REPO_ROOT)
+
+DATA_DIR = os.path.join(HERE, "data")
+RESULTS_DIR = os.path.join(HERE, "results")
+SAVED_MODELS_DIR = os.path.join(HERE, "saved_models")
+POOL_DIR = os.path.join(DATA_DIR, "llm_candidates")
+
+DATASETS = [
+    "llmrouter_generic", "memory_locomo", "memory_longmemeval", "timeseries",
+    "video", "multimodal_geometry3k", "multimodal_mathvista", "personalized",
+]
+
+# ── Router categories ────────────────────────────────────────────────────
+EMBED_ROUTERS = ["knnrouter", "svmrouter", "mlprouter", "mfrouter",
+                 "elorouter", "graphrouter", "routerdc", "hybrid_llm"]
+BASELINE_ROUTERS = ["largest_llm", "smallest_llm"]
+GENERIC_ROUTERS = ["gmtrouter", "personalizedrouter"]   # trained via registry, routed via route_single
+HEAVY_ROUTERS = ["causallm_router"]                      # LoRA finetune + vLLM, 2-stage subprocess
+API_ROUTERS = ["knnmultiroundrouter", "llmmultiroundrouter", "router_r1", "automix"]
+
+LOCAL_ROUTERS = EMBED_ROUTERS + BASELINE_ROUTERS + GENERIC_ROUTERS + HEAVY_ROUTERS
+ALL_ROUTERS = LOCAL_ROUTERS + API_ROUTERS
+
+with open(os.path.join(HERE, "configs", "hparams.yaml")) as _f:
+    ROUTER_HPARAMS = yaml.safe_load(_f)
+
+
+# ── Reward preprocessing (GraphRouter-style) ─────────────────────────────
+def load_pricing():
+    with open(os.path.join(POOL_DIR, "default_llm.json")) as f:
+        llm_data = json.load(f)
+    return {name: (info["input_price"], info["output_price"]) for name, info in llm_data.items()}
+
+
+def row_costs(df, pricing):
+    ip = df["model_name"].map(lambda m: pricing.get(m, (0.0, 0.0))[0])
+    op = df["model_name"].map(lambda m: pricing.get(m, (0.0, 0.0))[1])
+    return (df.get("input_tokens", 0) * ip + df.get("output_tokens", 0) * op) / 1e6
+
+
+def preprocess_training_data(train_path, pricing, alpha, beta):
+    """Replace `performance` with alpha*norm(perf) - beta*norm(cost); return temp path."""
+    df = pd.read_json(train_path, lines=True)
+    costs = row_costs(df, pricing).values.astype(float)
+    perf = df["performance"].values.astype(float)
+    norm_p = (perf - perf.min()) / (perf.max() - perf.min() + 1e-12)
+    norm_c = (costs - costs.min()) / (costs.max() - costs.min() + 1e-12)
+    df["performance"] = alpha * norm_p - beta * norm_c
+    fd, tmp = tempfile.mkstemp(suffix=".jsonl")
+    os.close(fd)
+    df.to_json(tmp, orient="records", lines=True)
+    return tmp
+
+
+# ── Config builder ───────────────────────────────────────────────────────
+def build_config(router, dataset, alpha, beta, train_path=None):
+    d = os.path.join(DATA_DIR, dataset)
+    tag = f"{dataset}_a{alpha}_b{beta}"
+    ext = ".pth" if router == "routerdc" else (".pt" if router == "graphrouter" else ".pkl")
+    # Trainers resolve save_model_path relative to the llmrouter package dir,
+    # so "saved_models/..." lands at <repo>/llmrouter/saved_models/... ; the
+    # load path is resolved from the repo root and must carry the prefix.
+    save_rel = os.path.join("saved_models", router, f"{router}_{tag}{ext}")
+    load_rel = os.path.join("llmrouter", save_rel)
+    cfg = {
+        "data_path": {
+            "routing_data_train": train_path or os.path.join(d, "routing_data_train.jsonl"),
+            "routing_data_test": os.path.join(d, "routing_data_test.jsonl"),
+            "query_embedding_data": os.path.join(d, "query_embeddings_train.pt"),
+            "llm_data": os.path.join(POOL_DIR, "default_llm.json"),
+            "llm_embedding_data": os.path.join(POOL_DIR, "default_llm_embeddings.json"),
+        },
+        "model_path": {
+            "ini_model_path": "",
+            "save_model_path": save_rel,
+            "load_model_path": load_rel,
+        },
+        "metric": {"weights": {"performance": alpha, "cost": beta, "llm_judge": 0}},
+        "hparam": dict(ROUTER_HPARAMS.get(router, {})),
+    }
+    if router == "routerdc":
+        cfg["model_path"]["backbone_model"] = "microsoft/mdeberta-v3-base"
+        cfg["model_path"]["load_model_path"] = save_rel
+    elif router == "hybrid_llm":
+        cfg["router_mode"] = "deterministic"
+        cfg["router_tau"] = 0.1
+        cfg["router_threshold"] = 0.5
+    elif router == "causallm_router":
+        cfg["model_path"]["save_model_path"] = os.path.join(
+            "saved_models", "causallm_router", f"causallm_{tag}")
+        cfg["model_path"]["load_model_path"] = os.path.join(
+            "llmrouter", "saved_models", "causallm_router", f"causallm_{tag}", "merged")
+    elif router in API_ROUTERS:
+        cfg["api_endpoint"] = os.environ.get("LLM_API_ENDPOINT", "https://api.together.xyz/v1")
+        cfg["api_key"] = os.environ.get("LLM_API_KEY")
+        if router == "router_r1":
+            cfg["router_r1_api_base"] = os.environ.get("ROUTER_R1_API_BASE")
+            cfg["router_r1_api_key"] = os.environ.get("ROUTER_R1_API_KEY", "EMPTY")
+    return cfg
+
+
+def write_yaml(cfg):
+    fd, path = tempfile.mkstemp(suffix=".yaml")
+    with os.fdopen(fd, "w") as f:
+        yaml.dump(cfg, f)
+    return path
+
+
+# ── Train ────────────────────────────────────────────────────────────────
+def train_router(router, cfg, yaml_path, device):
+    from llmrouter.cli.router_train import ROUTER_TRAINER_REGISTRY
+    if router in BASELINE_ROUTERS:
+        from llmrouter.models import LargestLLM, SmallestLLM
+        cls = LargestLLM if router == "largest_llm" else SmallestLLM
+        return cls(yaml_path)
+    router_cls, trainer_cls = ROUTER_TRAINER_REGISTRY[router]
+    r = router_cls(yaml_path)
+    if router == "routerdc":
+        r.model.float()
+    trainer = trainer_cls(router=r, device=device)
+    trainer.train()
+    return r
+
+
+# ── Route test queries ───────────────────────────────────────────────────
+def route_test_queries(router, r, cfg, dataset, device):
+    import torch
+    d = os.path.join(DATA_DIR, dataset)
+    test_df = pd.read_json(cfg["data_path"]["routing_data_test"], lines=True)
+    uq = test_df.groupby("query", sort=False).first().reset_index()
+
+    if router in BASELINE_ROUTERS:
+        best = r.route_single({"query": "probe"})["model_name"]
+        return [{"query": q, "routed_model": best} for q in uq["query"]]
+
+    if router == "elorouter":
+        from llmrouter.utils import load_model
+        elo = load_model(os.path.join(REPO_ROOT, cfg["model_path"]["load_model_path"]))
+        best = elo.index[0]
+        return [{"query": q, "routed_model": best} for q in uq["query"]]
+
+    emb = None
+    emb_path = os.path.join(d, "query_embeddings_test.pt")
+    if os.path.exists(emb_path):
+        emb = torch.load(emb_path, map_location="cpu")
+
+    if router in ("knnrouter", "svmrouter"):
+        from llmrouter.utils import load_model
+        m = load_model(os.path.join(REPO_ROOT, cfg["model_path"]["load_model_path"]))
+        out = []
+        for _, row in uq.iterrows():
+            e = emb[int(row["embedding_id"])].numpy().reshape(1, -1)
+            out.append({"query": row["query"], "routed_model": m.predict(e)[0]})
+        return out
+
+    if router == "mlprouter":
+        from llmrouter.models.mlprouter.router import MLPClassifierNN
+        from llmrouter.utils import load_model
+        sd = load_model(os.path.join(REPO_ROOT, cfg["model_path"]["load_model_path"]))
+        net = MLPClassifierNN(input_dim=r.input_dim,
+                              hidden_layer_sizes=cfg["hparam"]["hidden_layer_sizes"],
+                              num_classes=r.num_classes,
+                              activation=cfg["hparam"]["activation"])
+        net.load_state_dict(sd)
+        net.eval()
+        out = []
+        for _, row in uq.iterrows():
+            e = emb[int(row["embedding_id"])].float().unsqueeze(0)
+            with torch.no_grad():
+                idx = net.predict(e).item()
+            out.append({"query": row["query"], "routed_model": r.idx_to_model[idx]})
+        return out
+
+    if router == "mfrouter":
+        from llmrouter.models.mfrouter.router import BilinearMF
+        from llmrouter.utils import load_model
+        sd = load_model(os.path.join(REPO_ROOT, cfg["model_path"]["load_model_path"]))
+        mf = BilinearMF(cfg["hparam"]["latent_dim"], len(r.model_to_idx), cfg["hparam"]["text_dim"])
+        mf.load_state_dict(sd)
+        mf.eval()
+        out = []
+        for _, row in uq.iterrows():
+            q = mf.project_text(emb[int(row["embedding_id"])].float())
+            idx = torch.argmax(mf.score_all(q)).item()
+            out.append({"query": row["query"], "routed_model": r.idx_to_model[idx]})
+        return out
+
+    if router == "graphrouter":
+        load_path = os.path.join(REPO_ROOT, cfg["model_path"]["load_model_path"])
+        if os.path.exists(load_path):
+            r.gnn_predictor.model.load_state_dict(torch.load(load_path, map_location="cpu"))
+        test_emb = np.array([emb[int(row["embedding_id"])].numpy() for _, row in uq.iterrows()])
+        n_test = len(test_emb)
+        all_emb = np.vstack([r.query_embedding_list, test_emb])
+        all_perf = np.concatenate([r.performance_list, np.zeros(n_test * r.num_llms)])
+        n_q = len(all_emb)
+        org = [q for q in range(n_q) for _ in range(r.num_llms)]
+        des = list(range(r.num_llms)) * n_q
+        n_e = n_q * r.num_llms
+        n_train = r.num_queries_train
+        m_train = torch.zeros(n_e); m_train[:n_train * r.num_llms] = 1
+        m_test = torch.zeros(n_e); m_test[n_train * r.num_llms:] = 1
+        data = r.form_data.formulation(
+            query_feature=all_emb, llm_feature=r.llm_embedding,
+            org_node=org, des_node=des, edge_feature=all_perf,
+            label=all_perf.reshape(-1, 1), edge_mask=m_test, train_mask=m_train,
+            valide_mask=torch.zeros(n_e), test_mask=m_test)
+        pred = r.gnn_predictor.predict(data)[-n_test:]
+        return [{"query": row["query"], "routed_model": r.model_names[pred[i].item()]}
+                for i, (_, row) in enumerate(uq.iterrows())]
+
+    if router == "routerdc":
+        save_dir = os.path.join(REPO_ROOT, os.path.dirname(cfg["model_path"]["save_model_path"]))
+        ckpt = next((p for p in
+                     (os.path.join(save_dir, "best_model.pth"),
+                      os.path.join(save_dir, "best_training_model.pth"),
+                      os.path.join(REPO_ROOT, cfg["model_path"]["save_model_path"]))
+                     if os.path.exists(p)), None)
+        if ckpt:
+            r.model.load_state_dict(torch.load(ckpt, map_location=device))
+        r.model = r.model.to(device).eval()
+        names = r.test_dataset.router_node
+        out = []
+        with torch.no_grad():
+            for _, row in uq.iterrows():
+                toks = r.tokenizer(row["query"], max_length=512, padding="max_length",
+                                   truncation=True, return_attention_mask=True,
+                                   add_special_tokens=True, return_tensors="pt").to(device)
+                res = r.route({"input_ids": toks["input_ids"],
+                               "attention_mask": toks["attention_mask"],
+                               "temperature": 1.0})
+                out.append({"query": row["query"],
+                            "routed_model": names[res["predictions"][0].item()]})
+        return out
+
+    if router == "hybrid_llm":
+        from llmrouter.utils import load_model
+        m = load_model(os.path.join(REPO_ROOT, cfg["model_path"]["load_model_path"]))
+        out = []
+        for _, row in uq.iterrows():
+            e = emb[int(row["embedding_id"])].numpy().reshape(1, -1)
+            score = max(0.0, min(1.0, float(m.predict(e)[0])))
+            chosen = r.small_model_name if score >= r.router_threshold else r.large_model_name
+            out.append({"query": row["query"], "routed_model": chosen})
+        return out
+
+    # generic fallback (gmtrouter, personalizedrouter, api routers with route_single)
+    out = []
+    for _, row in uq.iterrows():
+        res = r.route_single({"query": row["query"]})
+        model = res.get("model_name") or res.get("routed_model")
+        out.append({"query": row["query"], "routed_model": model})
+    return out
+
+
+# ── Evaluate by replaying recorded outcomes ──────────────────────────────
+def evaluate(routing_results, test_path, pricing, alpha, beta):
+    test_df = pd.read_json(test_path, lines=True)
+    rows = []
+    for rr in routing_results:
+        m = test_df[(test_df["query"] == rr["query"]) &
+                    (test_df["model_name"] == rr["routed_model"])]
+        if len(m) > 0:
+            row = m.iloc[0]
+            ip, op = pricing.get(rr["routed_model"], (0.0, 0.0))
+            price = (row.get("input_tokens", 0) * ip + row.get("output_tokens", 0) * op) / 1e6
+            rows.append({"routed_model": rr["routed_model"], "performance": row["performance"],
+                         "input_tokens": row.get("input_tokens", 0),
+                         "output_tokens": row.get("output_tokens", 0), "price_cost": price})
+    df = pd.DataFrame(rows).dropna(subset=["performance"])
+    if not len(df):
+        return None
+    perfs, costs = df["performance"].values, df["price_cost"].values
+    norm_p = (perfs - perfs.min()) / (perfs.max() - perfs.min() + 1e-12)
+    norm_c = (costs - costs.min()) / (costs.max() - costs.min() + 1e-12)
+    dist = df["routed_model"].value_counts()
+    return {
+        "avg_performance": round(float(df["performance"].mean()), 4),
+        "avg_input_tokens": round(float(df["input_tokens"].mean()), 1),
+        "avg_output_tokens": round(float(df["output_tokens"].mean()), 1),
+        "avg_token_cost": round(float((df["input_tokens"] + df["output_tokens"]).mean()), 1),
+        "avg_price_cost": round(float(df["price_cost"].mean()), 8),
+        "avg_reward": round(float((alpha * norm_p - beta * norm_c).mean()), 4),
+        "num_queries": int(len(df)),
+        "routing_distribution": {m: int(c) for m, c in dist.items()},
+    }
+
+
+# ── One job ──────────────────────────────────────────────────────────────
+def result_path(dataset, router, alpha, beta):
+    return os.path.join(RESULTS_DIR, f"{dataset}_{router}_a{alpha}_b{beta}.json")
+
+
+def run_job(router, dataset, alpha, beta, device):
+    out_path = result_path(dataset, router, alpha, beta)
+    if os.path.exists(out_path):
+        print(f"[skip] {dataset} x {router} (result exists)")
+        return True
+
+    pricing = load_pricing()
+    train_path = os.path.join(DATA_DIR, dataset, "routing_data_train.jsonl")
+    tmp_train = None
+    if not (alpha == 1.0 and beta == 0.0) and router not in BASELINE_ROUTERS:
+        tmp_train = preprocess_training_data(train_path, pricing, alpha, beta)
+
+    cfg = build_config(router, dataset, alpha, beta, train_path=tmp_train)
+    yaml_path = write_yaml(cfg)
+    try:
+        if router == "causallm_router":
+            ok = run_causallm_stages(dataset, alpha, beta, yaml_path, device)
+            if not ok:
+                return False
+            return os.path.exists(out_path)
+
+        print(f"[train] {dataset} x {router} (alpha={alpha}, beta={beta})")
+        r = train_router(router, cfg, yaml_path, device)
+        print(f"[route] {dataset} x {router}")
+        routing = route_test_queries(router, r, cfg, dataset, device)
+        metrics = evaluate(routing, cfg["data_path"]["routing_data_test"], pricing, alpha, beta)
+        if metrics is None:
+            print(f"[fail]  {dataset} x {router}: no valid replay rows")
+            return False
+        summary = {"router": router, "dataset": dataset, "alpha": alpha, "beta": beta, **metrics}
+        os.makedirs(RESULTS_DIR, exist_ok=True)
+        with open(out_path, "w") as f:
+            json.dump(summary, f, indent=2)
+        print(f"[done]  {dataset} x {router}: perf={metrics['avg_performance']} "
+              f"reward={metrics['avg_reward']} -> {out_path}")
+        return True
+    except Exception as e:
+        print(f"[fail]  {dataset} x {router}: {type(e).__name__}: {e}")
+        return False
+    finally:
+        os.unlink(yaml_path)
+        if tmp_train and os.path.exists(tmp_train):
+            os.unlink(tmp_train)
+
+
+def run_causallm_stages(dataset, alpha, beta, yaml_path, device):
+    """Train and vLLM-infer in separate processes (a single process OOMs one GPU)."""
+    env = dict(os.environ)
+    env.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+    base = [sys.executable, os.path.join(HERE, "_causallm_stage.py"),
+            "--dataset", dataset, "--alpha", str(alpha), "--beta", str(beta),
+            "--yaml", yaml_path, "--device", device]
+    merged = os.path.join(REPO_ROOT, "llmrouter", "saved_models",
+                          "causallm_router", f"causallm_{dataset}_a{alpha}_b{beta}", "merged")
+    if not os.path.isdir(merged):
+        print(f"[train] {dataset} x causallm_router (subprocess, LoRA)")
+        if subprocess.run(base + ["--stage", "train"], env=env).returncode != 0:
+            print("[fail]  causallm train stage")
+            return False
+    print(f"[route] {dataset} x causallm_router (subprocess, vLLM)")
+    if subprocess.run(base + ["--stage", "infer"], env=env).returncode != 0:
+        print("[fail]  causallm infer stage")
+        return False
+    return True
+
+
+# ── Main ─────────────────────────────────────────────────────────────────
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--datasets", default="all",
+                        help="'all' or comma-separated names: " + ",".join(DATASETS))
+    parser.add_argument("--routers", default="local",
+                        help="'all', 'local', or comma-separated names: " + ",".join(ALL_ROUTERS))
+    parser.add_argument("--alpha", type=float, default=1.0, help="performance weight")
+    parser.add_argument("--beta", type=float, default=0.0, help="cost weight")
+    parser.add_argument("--device", default="cuda")
+    parser.add_argument("--include-api-routers", action="store_true",
+                        help="also run routers that make live LLM API calls")
+    args = parser.parse_args()
+
+    datasets = DATASETS if args.datasets == "all" else args.datasets.split(",")
+    if args.routers == "all":
+        routers = ALL_ROUTERS if args.include_api_routers else LOCAL_ROUTERS
+    elif args.routers == "local":
+        routers = LOCAL_ROUTERS
+    else:
+        routers = args.routers.split(",")
+
+    bad = [d for d in datasets if d not in DATASETS] + [r for r in routers if r not in ALL_ROUTERS]
+    if bad:
+        parser.error(f"unknown names: {bad}")
+
+    api_requested = [r for r in routers if r in API_ROUTERS]
+    if api_requested and not args.include_api_routers:
+        print(f"note: skipping API routers {api_requested} (pass --include-api-routers to run them)")
+        routers = [r for r in routers if r not in API_ROUTERS]
+    if api_requested and args.include_api_routers and not os.environ.get("LLM_API_KEY"):
+        print("warning: LLM_API_KEY not set; API routers will likely fail")
+
+    missing = [d for d in datasets
+               if not os.path.exists(os.path.join(DATA_DIR, d, "routing_data_train.jsonl"))]
+    if missing:
+        sys.exit(f"data missing for {missing}. Run: python download_data.py && python generate_embeddings.py")
+
+    print(f"Sweep: {len(datasets)} datasets x {len(routers)} routers "
+          f"(alpha={args.alpha}, beta={args.beta})\n")
+    ok = fail = 0
+    for ds in datasets:
+        for r in routers:
+            if run_job(r, ds, args.alpha, args.beta, args.device):
+                ok += 1
+            else:
+                fail += 1
+    print(f"\nSweep complete: {ok} succeeded, {fail} failed. "
+          f"Aggregate with: python aggregate_results.py")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

One-command pipeline to **train and evaluate every router on the 8 xRouteBench datasets**, including cost-aware (Pareto) training.

```bash
python download_data.py            # pull data from HF ulab-ai/xRouteBench
python generate_embeddings.py      # Qwen3-Embedding-0.6B, matches original setup
python run_pipeline.py --datasets all --routers local     # 13 routers x 8 datasets, zero API cost
python aggregate_results.py --csv  # per-dataset tables + overall ranking
```

## Contents

- `download_data.py` — HF download → the `routing_data_{train,test}.jsonl` layout routers expect
- `generate_embeddings.py` — regenerates query/candidate embeddings (last-token pool, L2-norm)
- `run_pipeline.py` — train + route + **replay-evaluate** (no API calls for the 13 local routers); `--alpha/--beta` composite reward (GraphRouter-style); resumable (existing results skipped)
- `_causallm_stage.py` — causallm train/infer as **separate processes** (one process OOMs a single 48GB GPU)
- `aggregate_results.py`, `configs/hparams.yaml`, `README.md`

## Router coverage (17)

| Category | Routers |
|---|---|
| Embedding-based | knn, svm, mlp, mf, elo, graphrouter, routerdc, hybrid_llm |
| Baselines | largest_llm, smallest_llm |
| Generic trainable | gmtrouter, personalizedrouter |
| Heavy | causallm_router (LoRA Llama-2-7b + vLLM) |
| API-calling (`--include-api-routers`) | knnmultiroundrouter, llmmultiroundrouter, router_r1, automix |

## Tested

Smoke-tested end-to-end on `video`: download → embeddings → knn/svm/elo/mlp/baselines at α=1.0 (baseline numbers match published results exactly) and knn/svm at α=0.6/β=0.4 (routers correctly shift to cheaper models, 4× price drop) → aggregation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)