### PR TITLE
Deploy GitHub Pages workflow from website branch

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,8 +1,8 @@
-name: Deploy preview site
+name: Deploy website
 
 on:
   push:
-    branches: [main]
+    branches: [website]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- run the GitHub Pages workflow when `website` changes instead of only on `main`
- rename the workflow from preview deployment to website deployment

## Validation
- `mkdocs build`
- `git diff --check`

After merging, set **Settings → Pages → Source** to **GitHub Actions** so this workflow can publish `https://ulab-uiuc.github.io/LLMRouter/`. 